### PR TITLE
Update project links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ tmp/
 ## OS
 .DS_Store
 Thumbs.db
-
+.backups
 ## Reverse-engineered artifacts (Il2CppDumper / Cpp2IL output, not for commit)
 dump.cs
 il2cpp.h

--- a/DorkNet.Server/site/src/App.tsx
+++ b/DorkNet.Server/site/src/App.tsx
@@ -32,7 +32,7 @@ export function App() {
         <div className="mx-auto max-w-6xl px-4 sm:px-6 py-4 flex flex-wrap items-center justify-between gap-2">
           <span>DorkNet — a private Rec Room server.</span>
           <span>
-            <a className="hover:text-ink-200" href="https://github.com/Alexa-RR/Dorknet">GitHub</a>
+            <a className="hover:text-ink-200" href="https://github.com/DorkSquad/Dorknet">GitHub</a>
             <span className="mx-2">·</span>
             <a className="hover:text-ink-200" href="/admin">Admin</a>
           </span>

--- a/DorkNet.Server/wwwroot/feed/index.html
+++ b/DorkNet.Server/wwwroot/feed/index.html
@@ -46,7 +46,7 @@
     </main>
 
     <footer class="site-footer">
-        <p>DorkNet · a private Rec Room server · <a href="https://github.com/Alexa-RR/Dorknet">GitHub</a></p>
+        <p>DorkNet · a private Rec Room server · <a href="https://github.com/DorkSquad/Dorknet">GitHub</a></p>
     </footer>
 
     <div id="toast" class="toast" hidden></div>

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 DorkNet — Rec Room Private Server
-Copyright (C) 2026 Alexa <https://github.com/Alexa-RR/Dorknet>
+Copyright (C) 2026 DorkSquad <https://github.com/DorkSquad/Dorknet>
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published
@@ -28,7 +28,7 @@ covered by AGPL §13 — you must:
   2. Preserve this NOTICE file in your distribution.
 
   3. Credit the upstream project visibly. At minimum:
-       "Based on DorkNet (https://github.com/Alexa-RR/Dorknet) by Alexa,
+       "Based on DorkNet (https://github.com/DorkSquad/Dorknet) by DorkSquad,
         licensed AGPL-3.0."
      Acceptable placements: README, server console banner, in-game
      credits screen, or web-facing footer of any deployment dashboard.


### PR DESCRIPTION
## Summary
- Update public project links to the current GitHub location.
- Ignore local mirror backup folders.

## Checks
- Not run; text/link-only change.