### PR TITLE
Refresh main docs

### DIFF
--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -1,8 +1,8 @@
 # Branches
 
-DorkNet maintains a long-lived branch per supported Rec Room client
-build. Each branch is an independent fork of the server + client patcher
-tuned to that build's wire protocol. Pick the one matching your install.
+DorkNet keeps one long-lived branch for each supported Rec Room client
+build. Each branch carries the server and client patcher for that
+build's wire protocol. Pick the branch that matches your install.
 
 ## Active branches
 
@@ -27,8 +27,9 @@ tuned to that build's wire protocol. Pick the one matching your install.
   - Diverges from `december-2020-12-18` by ~170 files; cannot be
     unified with the plugin abstraction alone.
 
-Setup for either is the same — see [docs/advanced-setup.md](docs/advanced-setup.md)
-(starts with a "pick your branch" step).
+Setup starts the same way for both branches: pick the branch, then
+follow that branch's own deploy notes. See
+[docs/advanced-setup.md](docs/advanced-setup.md).
 
 ## How to pick
 
@@ -44,8 +45,8 @@ If you don't know which Rec Room build you have, check:
 ## Machine-readable manifest
 
 [`versions.json`](versions.json) carries the same information in a
-format the Easy launcher and install scripts can consume directly. Add
-new versions there too when a new branch lands.
+format the Easy launcher and install scripts can read directly. When a
+new version branch lands, add it there too.
 
 ## Adding a new version branch
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ Thanks for your interest. A few ground rules before you open a PR.
 - **C#**: nullable enabled. Match the file you're editing. No regions, no
   multi-paragraph XML docs, no async-without-await.
 - **TypeScript / React**: existing patterns — function components, named
-  exports, tailwind classes, no CSS modules. Lint with `npm run lint` from
-  `admin-ui/`.
+  exports, tailwind classes, no CSS modules. On a version branch, lint
+  with `npm run lint` from `DorkNet.Server/admin-ui/`.
 - **No AI-co-author trailers in commit messages.** Use a real attribution
   line or none at all.
 
@@ -44,10 +44,12 @@ metadata, or use GitHub's private vulnerability reporting.
 ## Setting up a dev environment
 
 See [docs/advanced-setup.md](docs/advanced-setup.md) for the full server
-stack. For just hacking on the admin UI:
+stack. The server and admin UI live on the version branches, not on
+`main`. For just hacking on the admin UI after you check out a version
+branch:
 
 ```bash
-cd admin-ui
+cd DorkNet.Server/admin-ui
 npm install
 npm run dev
 ```

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,8 +1,9 @@
 # Disclaimer
 
-DorkNet is an independent, fan-made, clean-room reimplementation of the
-backend protocol used by the **2020 release of Rec Room** (build
-`Recroom_Release` dated 2020.03.10).
+DorkNet is an independent, fan-made, clean-room reimplementation of
+backend protocols used by old **2020 Rec Room** builds. The supported
+client builds live on separate branches, currently March 2020 and
+December 2020.
 
 It is **not** affiliated with, endorsed by, or sponsored by:
 
@@ -30,10 +31,10 @@ DorkNet's repository **does not** contain:
 - Patched copies of `Recroom_Release.exe`, `global-metadata.dat`, or any
   Rec Room game file
 
-You must acquire the 2020.03.10 Rec Room client yourself through whatever
-means are legal in your jurisdiction (e.g. SteamDB depot tools against an
-account that owns Rec Room). The patcher runs on your machine, modifies
-files locally, and never uploads anything anywhere.
+You must acquire the matching 2020 Rec Room client yourself through
+whatever means are legal in your jurisdiction, for example SteamDB depot
+tools against an account that owns Rec Room. The patcher runs on your
+machine, modifies files locally, and never uploads the game anywhere.
 
 ## Use at your own risk
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ tuned to that build's wire protocol.
 | **Rec Room 2020.12.18** (December) | [`december-2020-12-18`](../../tree/december-2020-12-18) | Active |
 | **Rec Room 2020.03.10** (March) | [`march-2020-03-10`](../../tree/march-2020-03-10) | Active |
 
-See [BRANCHES.md](BRANCHES.md) for the full per-branch breakdown
-(supported features, schema notes, plugin compatibility). Programs that
-need the mapping in machine-readable form (the Easy launcher, install
-scripts) read it from [versions.json](versions.json).
+See [BRANCHES.md](BRANCHES.md) for the full per-branch breakdown:
+supported features, schema notes, and plugin compatibility. Tools that
+need the same list in machine-readable form read it from
+[versions.json](versions.json).
 
 This `main` branch is **docs-only** — it carries the project README, the
 manifest the launcher reads, the per-version setup guides, and the Easy
-app source. All actual server / patcher code lives on the per-version
+app source. Server and patcher code lives on the per-version
 branches above.
 
 ---
@@ -51,10 +51,10 @@ Pick a Rec Room build on first launch, host or join.
 
 ### Linux / macOS host — `dorknet-server` CLI
 
-Headless host-side CLI for Linux (x64/arm64), macOS (Intel/Apple
-Silicon), and Windows. Same server + tunnel pipeline as the GUI,
-suitable for a VPS or a permanent home server. Joiners still use the
-Windows launcher to apply the patch to their own Rec Room install.
+Command-line host for Linux (x64/arm64), macOS (Intel/Apple Silicon),
+and Windows. It runs the same server and tunnel flow as the GUI, so it
+works well on a VPS or permanent home server. Joiners still use the
+Windows launcher to patch their own Rec Room install.
 
 ```sh
 dorknet-server --photon-id YOUR-APPID --name "Sunday games"
@@ -64,16 +64,19 @@ dorknet-server --photon-id YOUR-APPID --name "Sunday games"
 
 ### Advanced — Docker / source
 
-For community-server hosts, modders, and contributors. Pick the branch
-matching your client build, clone, run.
+For community-server hosts, modders, and contributors. `main` is only
+the launcher and project docs, so the real server instructions live on
+the version branch you plan to run.
 
 ```bash
 # Example: hosting for December 2020.12.18 clients
 git clone --branch december-2020-12-18 https://github.com/DorkSquadRR/DorkNet
-cd DorkNet/docker
-cp .env.example .env  # fill in 2-3 values
-docker compose up -d
+cd DorkNet
 ```
+
+From there, follow that branch's `README.md` and `docs/deploy.md`.
+The December branch has the newer microservices/Dokploy path; March is
+the older single-server branch.
 
 → **[Advanced setup guide](docs/advanced-setup.md)**
 
@@ -120,7 +123,7 @@ branch's `BRANCHES.md` row for the exact deltas.
 - [Branch chart](BRANCHES.md) — which branch matches your client
 - [Easy setup](docs/easy-setup.md) — Windows GUI launcher
 - [Server CLI](docs/server-cli.md) — Linux / macOS / Windows headless
-- [Advanced setup](docs/advanced-setup.md) — Docker / VPS path
+- [Advanced setup](docs/advanced-setup.md) — source, Docker, VPS, and branch deploys
 - [Joining a server](docs/joining-a-server.md) — for players
 - [Photon setup](docs/photon-setup.md) — getting your AppIds
 - [Architecture](docs/architecture.md) — how the code is laid out

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,11 @@
 # DorkNet docs
 
-| Doc                                            | For who                                                |
+| Doc                                            | Who it's for                                           |
 | ---------------------------------------------- | ------------------------------------------------------ |
 | [../BRANCHES.md](../BRANCHES.md)               | Anyone picking which branch matches their Rec Room build |
 | [easy-setup.md](easy-setup.md)                 | Windows hosts using the desktop launcher              |
 | [server-cli.md](server-cli.md)                 | Linux / macOS hosts using the headless `dorknet-server` |
-| [advanced-setup.md](advanced-setup.md)         | Hosts running a community server on Docker / a VPS     |
+| [advanced-setup.md](advanced-setup.md)         | Source, Docker, VPS, and branch deploy notes           |
 | [joining-a-server.md](joining-a-server.md)     | Players whose friend gave them a join code             |
 | [photon-setup.md](photon-setup.md)             | How to get a free Photon Cloud account + AppIds        |
 | [architecture.md](architecture.md)             | Contributors hacking on the code                       |

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -1,154 +1,114 @@
-# Advanced mode — Docker stack
+# Advanced setup
 
-For hosts running a community server (more than ~10 concurrent players),
-doing custom modding work, or contributing to DorkNet itself.
+Use this path if you are running a community server, deploying to a VPS,
+testing the server from source, or working on DorkNet itself.
 
-If you just want to play with friends, the [easy-setup](easy-setup.md)
-desktop app is what you want.
+The important bit: `main` is not the server branch. It only has the
+launcher, the CLI, `versions.json`, and these shared docs. The actual
+ASP.NET server, admin UI, client mod, Dockerfile, and deploy scripts live
+on the version branches.
 
-## What you get
+## Pick the right branch
 
-- **server**: the ASP.NET Core backend
-- **postgres**: the canonical store (the desktop app uses SQLite; for >10
-  concurrent players, Postgres is what you want)
-- **redis**: cross-replica presence cache (skip with `REDIS_URL=` empty
-  to fall back to in-memory; loses presence on restart but otherwise fine)
-- **nginx**: TLS termination + multi-subdomain routing
-  (`api.*`, `auth.*`, `accounts.*`, `match.*`, `chat.*`, `cdn.*`, `commerce.*`,
-  `img.*`, `leaderboard.*`, `notify.*`)
+Use the branch that matches the Rec Room build your players will run.
 
-Behind a proper TLS certificate (Let's Encrypt via Caddy or Cloudflare
-Tunnel) this should comfortably run 50+ concurrent players on a $20/mo VPS.
-
-## Prerequisites
-
-- A Linux VPS (Debian 12 / Ubuntu 22.04 / etc.)
-- A domain you control with wildcard DNS pointing at the VPS
-  (`*.your-server.example.com → 1.2.3.4`)
-- Docker + Docker Compose
-
-## Setup
-
-### 1. Pick the branch matching your client build
-
-DorkNet keeps one branch per supported Rec Room build. See
-[`../BRANCHES.md`](../BRANCHES.md) for the full chart. Quick map:
-
-| Your Rec Room install | Branch to clone |
+| Rec Room install | Branch |
 |---|---|
-| 2020.12.18 (most common DorkNet target) | `december-2020-12-18` |
-| 2020.03.10 (or 2020.03.06) | `march-2020-03-10` |
+| 2020.12.18 | `december-2020-12-18` |
+| 2020.03.10 or 2020.03.06 | `march-2020-03-10` |
 
-### 2. Clone + configure
+The same list is in [`../BRANCHES.md`](../BRANCHES.md) and
+[`../versions.json`](../versions.json). If the client build is not in
+that list, DorkNet will not know how to talk to it.
+
+## Clone the server branch
+
+Example for December:
 
 ```bash
-# Replace the branch in --branch with the row that matched above.
 git clone --branch december-2020-12-18 https://github.com/DorkSquadRR/DorkNet
-cd DorkNet/docker
-
-cp .env.example .env
-$EDITOR .env  # fill in the values noted below
+cd DorkNet
 ```
 
-### Required `.env` values
-
-```env
-# Your domain. Server expects to find itself at *.DORKNET_DOMAIN.
-DORKNET_DOMAIN=your-server.example.com
-
-# A long random string. Used to sign JWTs.
-JWT_SECRET=$(openssl rand -base64 64)
-
-# Postgres password. Random, written once, kept in this file.
-POSTGRES_PASSWORD=$(openssl rand -base64 32)
-
-# Photon Cloud AppIds. Free tier at https://dashboard.photonengine.com
-PHOTON_APP_ID=your-photon-realtime-appid
-PHOTON_VOICE_APP_ID=your-photon-voice-appid  # optional
-PHOTON_CLOUD_REGION=eu  # eu, us, asia, jp, sa, kr, in, au, etc.
-
-# Steam Web API key — only needed if you want Steam logins to work.
-# Free at https://steamcommunity.com/dev/apikey
-STEAM_API_KEY=
-```
-
-### TLS
-
-The bundled nginx config terminates TLS but expects certificates to exist
-on the host. You have two reasonable paths:
-
-1. **Caddy in front** (recommended for new hosts) — replace the nginx
-   service with a Caddyfile; Caddy auto-fetches Let's Encrypt certs.
-2. **Cloudflare Tunnel** — DNS your wildcard at Cloudflare, run
-   `cloudflared` as another container, never expose port 443 to the
-   internet. The repo includes a sample `docker-compose.cloudflared.yml`.
-
-### Run it
+Example for March:
 
 ```bash
-docker compose up -d
-docker compose logs -f server
+git clone --branch march-2020-03-10 https://github.com/DorkSquadRR/DorkNet
+cd DorkNet
 ```
 
-First boot does:
+From that checkout, read the branch's own `README.md` first. If the
+branch has `docs/deploy.md`, use that as the production deploy guide.
+Those files are more accurate than any generic command copied from
+`main`, because each branch is laid out a little differently.
 
-1. Schema initialization (`EnsureCreated` from the entity classes)
-2. Legacy data upgrades (no-op on a fresh install)
-3. Seeds RR-Original rooms + store catalog
-4. Applies canonical room overrides (Crescendo, Paintball merge, etc.)
-5. Downloads the bundled room thumbnail images
+## What you usually need
 
-You should see `[boot] migrations complete` within ~3 seconds. Then the
-server is ready at `https://api.your-server.example.com/healthz`.
+For a real hosted server, plan on:
 
-## Patching the client to point here
+- a domain or tunnel that can route the Rec Room service subdomains,
+- a Photon Realtime AppId,
+- a Photon Voice AppId if you want in-game voice,
+- persistent storage for the server database,
+- object/blob storage if the branch's deploy guide calls for it,
+- the matching 2020 Rec Room client on each player machine.
 
-Same patcher as Easy mode, but you'll run it from the command line. The
-CLI installer ships on the version-specific branch (e.g.
-`december-2020-12-18`):
+For Photon setup, use [`photon-setup.md`](photon-setup.md).
 
-```powershell
-.\tools\install-melon.ps1 `
-  -RecRoomPath "C:\path\to\Recroom_Release_Data" `
-  -PhotonAppId "<your-photon-realtime-app-id>" `
-  -PhotonVoiceAppId "<your-photon-voice-app-id>"
-```
+## Running from source
 
-The installer drops the DorkNet MelonLoader mod (`DorkNet.ClientMod`)
-into the client's `Mods/` folder and writes its config under
-`MelonLoader/UserData/`.
-
-## Admin UI
-
-`https://admin.your-server.example.com` — log in with the first account
-you create (it auto-promotes to admin) or with the bootstrap credentials
-in your `.env` if you set `BOOTSTRAP_ADMIN_*`.
-
-## Backups
-
-Postgres is the only stateful service.
+On a version branch, the usual local loop is:
 
 ```bash
-docker compose exec postgres pg_dump -U dorknet dorknet > backup.sql
+dotnet run --project DorkNet.Server
 ```
 
-`data/images/` on the host is the image blob store. Back that up too.
+Then follow that branch's README for the exact environment variables,
+database settings, and client patching steps.
+
+For admin UI work on a version branch:
+
+```bash
+cd DorkNet.Server/admin-ui
+npm install
+npm run dev
+```
+
+For public site work, use the same pattern under `DorkNet.Server/site`.
+
+## Docker and production deploys
+
+There is no top-level `docker/` folder on the active branches.
+Start from the branch README and deploy guide instead.
+
+The version branches contain the current Dockerfile and deploy docs.
+December has the newer microservices/Dokploy path in `docs/deploy.md`.
+March is the older single-server branch. If you are unsure which one you
+are on, run:
+
+```bash
+git branch --show-current
+```
 
 ## Updating
 
+Branches are independent. Pulling `main` updates the launcher docs and
+manifest, not the server code you are running.
+
+To update a server checkout:
+
 ```bash
-cd DorkNet
+git checkout december-2020-12-18   # or march-2020-03-10
 git pull
-docker compose pull
-docker compose up -d
 ```
 
-The server runs all idempotent migrations on boot, so version upgrades
-are zero-downtime as long as the schema changes are additive.
+Then follow that branch's deploy guide for rebuild/restart steps.
 
-> ⚠️ `git pull` only fetches updates for **your current branch**.
-> DorkNet branches are independent — updates on `december-2020-12-18`
-> don't flow to `march-2020-03-10` and vice versa. If you've checked
-> out the wrong branch for your client, switching is a fresh
-> `git clone --branch ...` (the schema and Photon AppId requirements
-> differ).
+## Backups
+
+Back up the database and any blob/image storage before you upgrade. The
+exact paths depend on the branch and deploy mode, so use the branch's
+own deploy guide rather than guessing from this page.
+
+For the launcher/easy-mode database, the local SQLite file lives under
+the DorkNet app data folder shown in the launcher's Settings view.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
-│  Rec Room 2020.03.10 client (patched)                            │
+│  Supported 2020 Rec Room client (patched)                         │
 │  ┌────────────────────┐    ┌──────────────────────────────────┐  │
 │  │  IL2CPP game code  │    │  MelonLoader + client-mod        │  │
 │  │  • set_BaseUri     │←───│  • rewrites *.rec.net hosts      │  │
@@ -13,7 +13,7 @@
              │ HTTPS to *.your-server.example.com
              ▼
 ┌──────────────────────────────────────────────────────────────────┐
-│  DorkNet server (ASP.NET Core)                                   │
+│  DorkNet server from the matching version branch (ASP.NET Core)   │
 │                                                                  │
 │  Subdomain-multiplexed routing:                                  │
 │    api.*       → REST endpoints (rooms, players, store, etc.)    │

--- a/docs/easy-setup.md
+++ b/docs/easy-setup.md
@@ -20,8 +20,9 @@ single Windows app that:
 ## What you'll need
 
 - Windows 10 or 11 (Mac and Linux support are not planned)
-- A copy of **Rec Room 2020.03.10** — the specific old build DorkNet
-  targets. You acquire this yourself; see
+- A copy of a **supported 2020 Rec Room build**. The launcher can host
+  March 2020 or December 2020, and it will try to detect which one you
+  have. You acquire the game yourself; see
   [Getting the 2020 client](#getting-the-2020-client) below.
 - A free Photon Cloud account — the launcher walks you through this on
   first run.
@@ -75,9 +76,9 @@ once; future launches drop you straight into the main view.
 
 ## The setup wizard
 
-Five steps, top stepper shows your progress. **Back** and **Next** sit
-in the bottom bar; the choice cards on the first step auto-advance when
-clicked.
+The wizard has five steps. The stepper at the top shows where you are,
+and **Back** / **Next** stay in the bottom bar. On the first step, the
+choice cards move forward as soon as you click one.
 
 ### Step 1 — Pick a mode
 
@@ -234,8 +235,8 @@ patcher.
 
 ## Launching the game
 
-Once your server is live, the **LAUNCH REC ROOM** button (teal, sits
-next to **STOP**) becomes visible. Click it; the launcher starts your
+Once your server is live, the teal **LAUNCH REC ROOM** button appears
+next to **STOP**. Click it; the launcher starts your
 patched copy with the right command-line args. Toggle **Screen mode**
 in the header first if you want desktop play.
 
@@ -283,25 +284,26 @@ See [joining-a-server.md](joining-a-server.md) for the join-side flow.
 | Friends anywhere · Localtunnel | public HTTPS, anonymous | `https://<random>.loca.lt` | Default — friends connect from anywhere with just the join code |
 | Same WiFi only · sslip.io | no | `<lan-ip>.sslip.io` | LAN games, lowest latency, no internet exposure |
 
-Default mode is the right pick for >95% of cases. LAN mode is for when
+Default mode is the right pick for most people. LAN mode is for when
 everyone's in the same room and you do not want a public URL.
 
 ---
 
 ## Getting the 2020 client
 
-DorkNet doesn't ship the Rec Room game itself — that's Rec Room Inc.'s
+DorkNet doesn't ship the Rec Room game itself. That's Rec Room Inc.'s
 intellectual property. You acquire your own copy through legal means.
 
 Common paths:
-- If you bought Rec Room on Steam before 2020, you can use SteamDB depot
-  tools to download the old build (manifest `4651244957411961725` for
-  `Recroom_Release_Data`).
+- If you own Rec Room on Steam, SteamDB depot tools can download old
+  depots. Use the build that matches the branch you want to play:
+  March 2020 or December 2020.
 - Friends who already have a 2020 install can share files with you under
   whatever license terms apply on their end.
 
 DorkNet's authors can't help you obtain the game. Search the web for
-"Steam depot 2020.03.10 Rec Room" if you need pointers.
+"Steam depot Rec Room 2020.12.18" or "Steam depot Rec Room 2020.03.10"
+if you need pointers.
 
 ---
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -17,22 +17,22 @@ from DMCA. We minimize friction by never distributing Rec Room IP, never
 interfering with their live servers, and being explicit that this is for
 educational / private use only.
 
-### Why the 2020 build specifically? Will newer versions work?
+### Why old 2020 builds specifically? Will newer versions work?
 
-2020.03.10 is the last build before Rec Room shipped server-side
-ObscuredInt anti-cheat changes that would require deeper client patching.
-It's old enough to be effectively abandonware on Rec Room's roadmap, new
-enough to have most of the features people remember.
+DorkNet targets old 2020 clients because their network protocol is still
+small enough to reimplement cleanly. Newer Rec Room builds changed more
+of the auth, protocol, and client-side assumptions, so each later build
+would need real reverse-engineering work instead of a quick version bump.
 
-Newer builds (any Rec Room from late 2020 onward) aren't supported and
-won't be without significant additional reverse-engineering. PRs that
-add support for newer builds are welcome but expect scope creep.
+The supported builds are listed in [BRANCHES.md](../BRANCHES.md). Builds
+outside that table will not work unless someone adds a matching branch.
 
 ### Can I run a public server that anyone can join?
 
-Technically yes (just disable signup-disabled in admin settings). Legally
-risky — see the C&D answer above. Realistically, "public" private
-servers attract attention and shorten the project's lifespan.
+Technically yes, if you allow open signups in admin settings. It is
+legally risky, though; see the shutdown/legal answer above. Realistically,
+"public" private servers attract attention and shorten the project's
+lifespan.
 
 We recommend keeping servers small (friends + community), private
 (invite-only signups), and not advertised.
@@ -95,5 +95,5 @@ Most common causes, in order:
 4. **Localtunnel interstitial.** First time a joiner's machine hits a
    given `*.loca.lt` URL, Localtunnel may show a one-time "Click to
    Continue" page. Open the URL once in any browser and retry.
-4. **Junior account / accessibility settings.** Server settings → relax
+5. **Junior account / accessibility settings.** Server settings → relax
    moderation gates if friends are on accounts with parental controls.

--- a/docs/joining-a-server.md
+++ b/docs/joining-a-server.md
@@ -12,7 +12,8 @@ locally — nothing is sent anywhere until you actually launch the game.
 ## What you'll need
 
 - Windows 10 or 11
-- A copy of **Rec Room 2020.03.10** — your own, see
+- A copy of the **same 2020 Rec Room build your host is using**,
+  usually March 2020 or December 2020. Bring your own copy; see
   [Getting the 2020 client](easy-setup.md#getting-the-2020-client)
 - The join code your friend gave you (a base64-looking blob a few hundred
   characters long)

--- a/docs/server-cli.md
+++ b/docs/server-cli.md
@@ -4,8 +4,8 @@
 > on Windows still use the [Windows launcher](easy-setup.md) to apply
 > the patch to their copy of Rec Room.
 
-`dorknet-server` is a small command-line tool that does the host side
-of what the Windows launcher does: downloads the server build, opens a
+`dorknet-server` is a small command-line tool for hosting without the
+Windows launcher. It downloads the server build, opens a
 [Localtunnel](https://localtunnel.github.io/www/) HTTPS URL (or binds
 on the LAN), runs the server, and prints a join code. It runs on Linux,
 macOS, and Windows.
@@ -71,10 +71,13 @@ only).
 
 ## Usage
 
-The minimum invocation is just your Photon AppId:
+The minimum invocation is just your Photon AppId. For a predictable
+setup, pass the client build you want with `--version`:
 
 ```sh
-dorknet-server --photon-id 12345678-aaaa-bbbb-cccc-1234567890ab
+dorknet-server \
+  --photon-id 12345678-aaaa-bbbb-cccc-1234567890ab \
+  --version december_2020_12_18
 ```
 
 The CLI prints progress, then a join code:
@@ -88,7 +91,7 @@ DorkNet server CLI · v0.1.0
 
 [server] downloading…
             54.2%  (27.1 / 50.0 MB)
-[server] cached at /home/alex/.local/share/DorkNet/servers/march_2020_03_10
+[server] cached at /home/alex/.local/share/DorkNet/servers/december_2020_12_18
 [tunnel] starting localtunnel…
 [tunnel] live at https://lucky-pelican-42.loca.lt
 [server] starting…
@@ -129,8 +132,9 @@ down cleanly.
                        lan                   — same WiFi only, no tunnel
 --apex <hostname>      Wildcard apex. Required for --mode wildcard.
                        Example: dorknet.example.tunnelto.me
---version <key>        Rec Room version key. Default: march_2020_03_10
-                       (the only branch currently supported).
+--version <key>        Rec Room version key. Current CLI default:
+                       march_2020_03_10. Pass december_2020_12_18
+                       when hosting December clients.
 --server-dir <path>    Skip download — use a local build at this path.
                        Useful for dev work on the server itself.
 ```

--- a/launcher/README.md
+++ b/launcher/README.md
@@ -34,7 +34,7 @@ launcher/
     ├── VersionsManifest.cs    Fetches versions.json from main
     ├── ReleaseDownloader.cs   GitHub Releases API + artifact unpack
     ├── ServerProcess.cs       Spawns the downloaded server binary
-    ├── ClientPatcher.cs       Invokes install-plugin.ps1 from the unpacked patcher
+    ├── ClientPatcher.cs       Applies the manifest-based patcher zip
     ├── LocaltunnelInstaller.cs Downloads the Localtunnel .NET client
     ├── LocaltunnelTunnel.cs    Spawns the tunnel + parses the *.loca.lt URL
     ├── RecRoomPicker.cs       Microsoft.Win32.OpenFolderDialog
@@ -67,7 +67,7 @@ launcher release workflow once it exists).
 
 ## Dependencies on per-version branches
 
-The launcher fetches release artifacts from GitHub Releases tagged on
+The launcher fetches release files from GitHub Releases tagged on
 the per-version branches. See [RELEASES.md](RELEASES.md) for the
 exact naming convention each branch must follow.
 

--- a/launcher/RELEASES.md
+++ b/launcher/RELEASES.md
@@ -1,13 +1,13 @@
 # Release artifact contract
 
-The DorkNet Launcher (on `main`) reads
+The launcher on `main` reads
 [`/versions.json`](../versions.json) to find every supported per-version
-branch, then fetches release artifacts from each branch's GitHub
+branch, then fetches release files from each branch's GitHub
 Releases.
 
-Per-version branches must publish releases that follow this contract,
-otherwise the launcher reports "no release found" / "manifest missing"
-to users on host / join.
+Per-version branches need releases that follow this contract. If the
+assets are missing or named differently, users will see "no release
+found" or "manifest missing" when they host or join.
 
 ## Tag naming
 


### PR DESCRIPTION
Updates the main docs so they are branch-aware instead of March-only, removes stale Docker path guidance, and points server/admin work at the active version branches.