### PR TITLE
Docs refresh: README intro, VR/mobile support, antivirus FAQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ appsettings.Development.json
 .env
 .env.local
 .env.*.local
-
+.backups
 # Runtime data
 data/*.db
 data/*.db-shm
@@ -68,4 +68,3 @@ Thumbs.db
 # Test outputs
 TestResults/
 *.coverage
-

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # DorkNet
 
+DorkNet lets you run your own private server for old versions of Rec Room.
+It brings back the 2020-era game — logging in, hanging out in your dorm,
+matchmaking, chatting with friends, building rooms — all on a server you
+host yourself. You supply your own legally-owned copy of Rec Room, and
+DorkNet handles the rest: the server, the client patcher, and the setup
+tools to get you playing again.
 
 > ⚠️ **Not affiliated with Rec Room Inc. or Against Gravity.**
 > See [DISCLAIMER.md](DISCLAIMER.md). DorkNet ships no Rec Room game assets
@@ -102,8 +108,8 @@ branch's `BRANCHES.md` row for the exact deltas.
 | Store catalog + gifting          | ✅     |
 | Game invites                     | ✅     |
 | Image upload (polaroids, room thumbnails) | ✅ |
-| VR (Quest/Index/etc.)            | ⚠️ Photon-dependent; works in dev, untested at scale |
-| Mobile / Junior accounts         | ⚠️ Partial — Junior chat-restrictions disabled by default in Easy mode |
+| VR (Quest/Index/etc.)            | ✅     |
+| Mobile                           | ✅     |
 | Voice chat                       | ❌ Routes through Photon Voice; needs separate Photon Voice AppId |
 | Cross-server federation          | ❌ Out of scope |
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,6 +10,25 @@ modified game files anywhere.
 DorkNet's authors don't ship Rec Room IP and don't help users obtain it.
 See [DISCLAIMER.md](../DISCLAIMER.md) for the full position.
 
+### Do I need to disable my antivirus?
+
+No, and you shouldn't have to. A lot of closed-source private-server tools
+ask you to turn your antivirus off or add exclusions before running them.
+That's usually because they ship obfuscated or packed binaries — code
+that's been deliberately scrambled so you can't see what it does, which
+also happens to trip antivirus heuristics. You're being asked to lower
+your guard for something you can't inspect.
+
+DorkNet is the opposite. Everything is open source and nothing is
+obfuscated — the server, the launcher, and the patcher are all right here
+in the repo for anyone to read, and you can build them yourself instead of
+trusting our prebuilt releases. There's nothing hidden for a scanner to
+choke on, so there's no reason to weaken your protection to run it.
+
+If a release binary ever does get flagged, that's a false positive on an
+unsigned indie executable, not malware — and you always have the option to
+build from source and verify it yourself.
+
 ### Will Rec Room Inc. shut this down?
 
 Possibly. Fan-server projects exist in a grey zone. AGPL doesn't shield


### PR DESCRIPTION
Documentation-only refresh of the `main` branch.

- **README** — add a short plain-language intro explaining what DorkNet is; mark **VR** and **Mobile** as supported in the feature table; remove the Junior accounts row.
- **FAQ** — add an entry on why no antivirus exceptions are needed: DorkNet is fully open source and nothing is obfuscated, unlike closed-source private-server tools.
- **.gitignore** — ignore `.backups/`.