### PR TITLE
fix(cli): exit 0 on --help so CI smoke test passes

### DIFF
--- a/cli/DorkNet.ServerCli/DorkNet.ServerCli.csproj
+++ b/cli/DorkNet.ServerCli/DorkNet.ServerCli.csproj
@@ -6,6 +6,10 @@
          alongside Windows. The shared Backend classes are written to
          OperatingSystem.IsWindows()-gate any Windows-only paths. -->
     <TargetFramework>net9.0</TargetFramework>
+    <!-- Declared so a RID-less restore produces assets for every target the
+         CI matrix / release pipeline later publishes with no-restore. Without
+         this, RID-specific publish fails with NETSDK1047. -->
+    <RuntimeIdentifiers>win-x64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>DorkNet.ServerCli</RootNamespace>

--- a/cli/DorkNet.ServerCli/Program.cs
+++ b/cli/DorkNet.ServerCli/Program.cs
@@ -14,8 +14,15 @@ public static class Program
 {
     public static async Task<int> Main(string[] args)
     {
+        // --help / -h (and a bare invocation) print usage and exit cleanly.
+        if (args.Length == 0 || args.Contains("--help") || args.Contains("-h"))
+        {
+            PrintHelp();
+            return 0;
+        }
+
         var parsed = ParseArgs(args);
-        if (parsed is null) return 1; // ParseArgs already wrote --help or an error.
+        if (parsed is null) return 1; // ParseArgs already wrote the error.
 
         // Validate required values up front so the user sees the
         // failure before any download / process spin-up.
@@ -216,50 +223,52 @@ public static class Program
 
     private static ParsedArgs? ParseArgs(string[] args)
     {
-        if (args.Length == 0 || args.Contains("--help") || args.Contains("-h"))
-        {
-            PrintHelp();
-            return null;
-        }
-
         string photon = "", voice = "", region = "us";
         string mode = "localtunnel", apex = "", name = "DorkNet Server";
         string versionKey = "march_2020_03_10";
         string? serverDir = null;
 
-        for (int i = 0; i < args.Length; i++)
+        try
         {
-            string Next()
+            for (int i = 0; i < args.Length; i++)
             {
-                if (i + 1 >= args.Length)
-                    throw new ArgumentException($"missing value for {args[i]}");
-                return args[++i];
+                string Next()
+                {
+                    if (i + 1 >= args.Length)
+                        throw new ArgumentException($"missing value for {args[i]}");
+                    return args[++i];
+                }
+                switch (args[i])
+                {
+                    case "--photon-id":     photon = Next(); break;
+                    case "--voice-id":      voice = Next(); break;
+                    case "--region":        region = Next(); break;
+                    case "--mode":          mode = Next(); break;
+                    case "--apex":          apex = Next(); break;
+                    case "--name":          name = Next(); break;
+                    case "--version":       versionKey = Next(); break;
+                    case "--server-dir":    serverDir = Next(); break;
+                    default:
+                        Console.Error.WriteLine($"error: unknown arg '{args[i]}' (try --help)");
+                        return null;
+                }
             }
-            switch (args[i])
+
+            HostingMode parsedMode = mode.ToLowerInvariant() switch
             {
-                case "--photon-id":     photon = Next(); break;
-                case "--voice-id":      voice = Next(); break;
-                case "--region":        region = Next(); break;
-                case "--mode":          mode = Next(); break;
-                case "--apex":          apex = Next(); break;
-                case "--name":          name = Next(); break;
-                case "--version":       versionKey = Next(); break;
-                case "--server-dir":    serverDir = Next(); break;
-                default:
-                    Console.Error.WriteLine($"error: unknown arg '{args[i]}' (try --help)");
-                    return null;
-            }
+                "localtunnel" or "lt" or "internet" or "tunnel" => HostingMode.SingleOriginTunnel,
+                "wildcard" or "remote" or "tunnelto"            => HostingMode.RemoteWildcard,
+                "lan" or "local" or "wifi"                      => HostingMode.LocalNetwork,
+                _ => throw new ArgumentException($"unknown --mode '{mode}' (try localtunnel, wildcard, lan)"),
+            };
+
+            return new ParsedArgs(photon, voice, region, parsedMode, apex, name, versionKey, serverDir);
         }
-
-        HostingMode parsedMode = mode.ToLowerInvariant() switch
+        catch (ArgumentException ex)
         {
-            "localtunnel" or "lt" or "internet" or "tunnel" => HostingMode.SingleOriginTunnel,
-            "wildcard" or "remote" or "tunnelto"            => HostingMode.RemoteWildcard,
-            "lan" or "local" or "wifi"                      => HostingMode.LocalNetwork,
-            _ => throw new ArgumentException($"unknown --mode '{mode}' (try localtunnel, wildcard, lan)"),
-        };
-
-        return new ParsedArgs(photon, voice, region, parsedMode, apex, name, versionKey, serverDir);
+            Console.Error.WriteLine($"error: {ex.Message} (try --help)");
+            return null;
+        }
     }
 
     private static void PrintHelp()


### PR DESCRIPTION
The `build-cli` CI jobs fail because the smoke-test step runs `dorknet-server --help`, which prints usage correctly but exits with code **1**.

`ParseArgs` returned `null` for `--help`, and `Main` mapped any `null` to `return 1` — so a successful help print looked like a failure.

This change:
- Treats `--help` / `-h` / a bare invocation as a successful usage print (**exit 0**).
- Wraps the parse loop so a missing value (e.g. `--mode` with no argument) or an unknown `--mode` exits **1** with a clear message instead of throwing an unhandled exception.

Verified locally: `--help` → 0, no-args → 0, unknown arg → 1, missing value → 1.