### PR TITLE
fix(release): use -p: instead of /p: for Windows publish

### DIFF
--- a/.github/workflows/release-launcher.yml
+++ b/.github/workflows/release-launcher.yml
@@ -126,10 +126,10 @@ jobs:
             -c Release \
             -r "${{ matrix.rid }}" \
             --self-contained true \
-            /p:Version="$v" \
-            /p:AssemblyVersion="${v}.0" \
-            /p:FileVersion="${v}.0" \
-            /p:InformationalVersion="$v"
+            -p:Version="$v" \
+            -p:AssemblyVersion="${v}.0" \
+            -p:FileVersion="${v}.0" \
+            -p:InformationalVersion="$v"
 
       - name: Package
         shell: bash


### PR DESCRIPTION
The `build-server-cli (win-x64)` job in the release pipeline fails with `MSB1008: Only one project can be specified`.

On the Windows runner the step runs under Git bash, which applies MSYS path conversion to arguments starting with `/` — so `/p:Version=...` becomes `p:Version=...` and MSBuild treats it as a second project.

Switching to `-p:` (equivalent, but no leading slash) is safe across Linux, macOS, and Windows shells.