### PR TITLE
ci(release): grant contents:write to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
     tags:
       - 'v1-december-*'
 
+permissions:
+  contents: write   # create the GitHub release + upload assets
+
 jobs:
   release:
     runs-on: windows-latest


### PR DESCRIPTION
The release workflow creates a GitHub release and uploads the server + patcher assets, which requires the `contents: write` token scope. Declaring it explicitly (matching `release-launcher.yml` on `main`) lets the repo revert to a read-only default `GITHUB_TOKEN`.