### PR TITLE
launcher: fix Steamless download 404

### DIFF
--- a/launcher/Backend/SteamlessInstaller.cs
+++ b/launcher/Backend/SteamlessInstaller.cs
@@ -22,9 +22,12 @@ namespace DorkNet.Launcher.Backend;
 public static class SteamlessInstaller
 {
     private const string PinnedVersion = "v3.1.0.5";
+    // Upstream names the asset "Steamless.{ver}.-.by.atom0s.zip" — NOT
+    // "Steamless.{ver}.zip". Getting this wrong is a 404 at the
+    // "Unlock Rec Room from Steam" step.
     private const string ZipUrl =
         "https://github.com/atom0s/Steamless/releases/download/" +
-        PinnedVersion + "/Steamless." + PinnedVersion + ".zip";
+        PinnedVersion + "/Steamless." + PinnedVersion + ".-.by.atom0s.zip";
 
     private static readonly HttpClient Http = new()
     {


### PR DESCRIPTION
## Problem

The launcher's **"Unlock Rec Room from Steam (if needed)"** step failed with `404 (Not Found)`.

`SteamlessInstaller` built the release asset URL as:
```
.../download/v3.1.0.5/Steamless.v3.1.0.5.zip
```
but atom0s names the actual asset `Steamless.v3.1.0.5.-.by.atom0s.zip`. The version tag was correct — only the filename was wrong, so the download 404'd.

## Fix

Correct the asset filename in `ZipUrl`.

## Verification

- Confirmed against the live release: the corrected URL returns the asset (610 KB, passes the >500 KB sanity check).
- Confirmed `Steamless.CLI.exe` is at the zip root, so the extraction path logic is unchanged.
- `dotnet build -c Debug` succeeds (0 errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected the asset download URL format to properly align with GitHub release naming conventions, ensuring reliable installer functionality and asset retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->