### PR TITLE
Fix Crescendo SQLite upgrade collision

### DIFF
--- a/DorkNet.Server/Data/LegacyUpgrades.cs
+++ b/DorkNet.Server/Data/LegacyUpgrades.cs
@@ -180,8 +180,13 @@ public static class LegacyUpgrades
         // either no-op (Crescendo now exists) or the only writer.
         for (var attempt = 1; attempt <= 2; attempt++)
         {
-            var crescendoExists = await db.Rooms.AnyAsync(r => r.Name == "Crescendo", ct);
-            var bloodMoon = await db.Rooms.FirstOrDefaultAsync(r => r.Name == "BloodMoon", ct);
+            var renameCandidates = await db.Rooms
+                .Where(r => r.Name.ToLower() == "bloodmoon" || r.Name.ToLower() == "crescendo")
+                .ToListAsync(ct);
+            var crescendoExists = renameCandidates.Any(r =>
+                string.Equals(r.Name, "Crescendo", StringComparison.OrdinalIgnoreCase));
+            var bloodMoon = renameCandidates.FirstOrDefault(r =>
+                string.Equals(r.Name, "BloodMoon", StringComparison.OrdinalIgnoreCase));
 
             if (bloodMoon is null && crescendoExists)
             {
@@ -217,15 +222,15 @@ public static class LegacyUpgrades
                 {
                     // Both exist — the rename ran on a different row at
                     // some point, and the original BloodMoon row is now
-                    // a stale duplicate. Park it under CrescendoLegacy
-                    // and hide from browse so /goto/name/... still
+                    // a stale duplicate. Park it under a unique legacy
+                    // name and hide from browse so /goto/name/... still
                     // resolves Crescendo to the right row.
-                    bloodMoon.Name = "CrescendoLegacy";
+                    bloodMoon.Name = await PickUniqueRoomNameAsync(db, "CrescendoLegacy", bloodMoon.Id, ct);
                     bloodMoon.HiddenFromBrowse = true;
                     await db.SaveChangesAsync(ct);
                     logger.LogInformation(
-                        "[legacy-upgrade] RenameBloodMoonToCrescendo: applied — Rooms.Id={Id} parked as CrescendoLegacy (Crescendo already existed on a different row)",
-                        bloodMoon.Id);
+                        "[legacy-upgrade] RenameBloodMoonToCrescendo: applied — Rooms.Id={Id} parked as {Name} (Crescendo already existed on a different row)",
+                        bloodMoon.Id, bloodMoon.Name);
                     return;
                 }
             }
@@ -240,5 +245,23 @@ public static class LegacyUpgrades
                 if (bloodMoon is not null) db.Entry(bloodMoon).State = EntityState.Detached;
             }
         }
+    }
+
+    private static async Task<string> PickUniqueRoomNameAsync(
+        DorkNetDbContext db, string preferred, long currentRoomId, CancellationToken ct)
+    {
+        var taken = await db.Rooms
+            .Where(r => r.Id != currentRoomId && r.Name.ToLower().StartsWith(preferred.ToLower()))
+            .Select(r => r.Name)
+            .ToListAsync(ct);
+
+        if (!taken.Any(n => string.Equals(n, preferred, StringComparison.OrdinalIgnoreCase)))
+            return preferred;
+
+        var suffix = 2;
+        while (taken.Any(n => string.Equals(n, $"{preferred}{suffix}", StringComparison.OrdinalIgnoreCase)))
+            suffix++;
+
+        return $"{preferred}{suffix}";
     }
 }


### PR DESCRIPTION
## What changed

Fixes #21.

The December server could crash during startup when an older SQLite database had both the old `BloodMoon` room row and a `Crescendo` row already present. The legacy upgrade tried to rename `BloodMoon` into `Crescendo`, then SQLite rejected it because `Rooms.Name` is unique.

This makes the upgrade handle that state directly:

- finds `BloodMoon` and `Crescendo` case-insensitively so SQLite's name collation cannot surprise the check
- parks stale `BloodMoon` rows under a unique `CrescendoLegacy` name when `Crescendo` already exists
- keeps the real `Crescendo` row as the one `/goto/name/...` should resolve

## Validation

- `dotnet build DorkNet.Server\DorkNet.Server.csproj`

Build passed with existing nullable/unread-parameter warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced the database upgrade process to better handle legacy data conflicts and cleanly resolve duplicate entries during migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->