### PR TITLE
Fix notification URLs in HTTP deployments

### DIFF
--- a/DorkNet.Server/Controllers/API/Config/V1/ServiceUrlsController.cs
+++ b/DorkNet.Server/Controllers/API/Config/V1/ServiceUrlsController.cs
@@ -15,5 +15,5 @@ public class ServiceUrlsController(DomainConfig domain) : ControllerBase
 {
     [HttpGet("services")]
     public ActionResult<Dictionary<string, string>> Get()
-        => Ok(ConfigService.BuildServiceUrlMap(domain.Apex));
+        => Ok(ConfigService.BuildServiceUrlMap(domain));
 }

--- a/DorkNet.Server/Controllers/API/Notification/V2/NotificationController.cs
+++ b/DorkNet.Server/Controllers/API/Notification/V2/NotificationController.cs
@@ -16,7 +16,7 @@ public class NotificationController(DomainConfig domain) : ControllerBase
     public IActionResult Connect() => StatusCode(StatusCodes.Status410Gone, new
     {
         error = "use_signalr_hub",
-        hint = $"connect to {domain.Sub("notify")}/hub/v1 instead",
+        hint = $"connect to {domain.Url("notify", "/hub/v1")} instead",
     });
 
     /// <summary>GET <c>api/notification/hub/v1</c> — returns the
@@ -27,7 +27,7 @@ public class NotificationController(DomainConfig domain) : ControllerBase
     [HttpGet("/api/notification/hub/v1")]
     public IActionResult HubInfo() => Ok(new
     {
-        Url = $"https://{domain.Sub("notify")}/hub/v1",
+        Url = domain.Url("notify", "/hub/v1"),
         Protocol = "signalr",
         Version = 1,
     });

--- a/DorkNet.Server/Controllers/Ns/NsController.cs
+++ b/DorkNet.Server/Controllers/Ns/NsController.cs
@@ -37,13 +37,13 @@ public class NsController : ControllerBase
     // code: locker)" in BootSequence.
     [HttpGet("/", Order = -1000)]
     public ActionResult<Dictionary<string, string>> Root() =>
-        Ok(ConfigService.BuildServiceUrlMap(_domain.Apex));
+        Ok(ConfigService.BuildServiceUrlMap(_domain));
 
     // Some builds fetch /v1 or /v1/services directly
     [HttpGet("/v1")]
     [HttpGet("/v1/services")]
     public ActionResult<Dictionary<string, string>> Services() =>
-        Ok(ConfigService.BuildServiceUrlMap(_domain.Apex));
+        Ok(ConfigService.BuildServiceUrlMap(_domain));
 
     // Ping / health used by the client keep-alive loop
     [HttpGet("/v1/ping")]

--- a/DorkNet.Server/Services/ConfigService.cs
+++ b/DorkNet.Server/Services/ConfigService.cs
@@ -25,9 +25,9 @@ public class ConfigService(IConfiguration config, DomainConfig domain)
         return new RecRoomConfig
         {
             MessageOfTheDay = config["Server:MOTD"] ?? "Welcome to the private server!",
-            CdnBaseUri = $"https://{domain.Sub("cdn")}",
+            CdnBaseUri = domain.Url("cdn"),
             PhotonConfig = photon,
-            ServiceUrls = BuildServiceUrlMap(apex),
+            ServiceUrls = BuildServiceUrlMap(domain),
             ConfigTable = new Dictionary<string, string>
             {
                 // Season keys the 2019/2020 client checks at startup
@@ -110,12 +110,14 @@ public class ConfigService(IConfiguration config, DomainConfig domain)
     /// <see cref="DomainConfig.Apex"/>) so the map stays a single
     /// source of truth.</summary>
     public static Dictionary<string, string> BuildServiceUrlMap(string apex)
+        => BuildServiceUrlMap(new DomainConfig(apex));
+
+    public static Dictionary<string, string> BuildServiceUrlMap(DomainConfig domain)
     {
         var map = new Dictionary<string, string>(ServiceSubdomains.Length);
         foreach (var (service, sub) in ServiceSubdomains)
         {
-            var host = string.IsNullOrEmpty(sub) ? apex : $"{sub}.{apex}";
-            map[service] = $"https://{host}";
+            map[service] = domain.Url(sub);
         }
         return map;
     }

--- a/DorkNet.Server/Services/DomainConfig.cs
+++ b/DorkNet.Server/Services/DomainConfig.cs
@@ -11,8 +11,28 @@ namespace DorkNet.Server.Services;
 public sealed class DomainConfig
 {
     public string Apex { get; }
-    public DomainConfig(string apex) { Apex = apex; }
+    public string Scheme { get; }
+
+    public DomainConfig(string apex, string scheme = "https")
+    {
+        Apex = apex;
+        Scheme = NormalizeScheme(scheme);
+    }
+
     public string Sub(string prefix) => $"{prefix}.{Apex}";
+    public string Url(string prefix, string path = "")
+    {
+        var host = string.IsNullOrEmpty(prefix) ? Apex : Sub(prefix);
+        if (string.IsNullOrEmpty(path)) return $"{Scheme}://{host}";
+        return $"{Scheme}://{host}{(path.StartsWith('/') ? path : "/" + path)}";
+    }
+
     public static bool MatchesSubdomain(string host, string prefix)
         => host.StartsWith(prefix + ".", StringComparison.OrdinalIgnoreCase);
+
+    private static string NormalizeScheme(string? value)
+    {
+        var scheme = string.IsNullOrWhiteSpace(value) ? "https" : value.Trim().TrimEnd(':', '/', '\\').ToLowerInvariant();
+        return scheme is "http" or "https" ? scheme : "https";
+    }
 }

--- a/DorkNet.Server/Startup/MiddlewarePipelineExtensions.cs
+++ b/DorkNet.Server/Startup/MiddlewarePipelineExtensions.cs
@@ -70,7 +70,7 @@ public static class MiddlewarePipelineExtensions
             if (ctx.Request.Host.Host.Equals(domainCfg.Sub("api"), StringComparison.OrdinalIgnoreCase) &&
                 (ctx.Request.Path == "/admin" || ctx.Request.Path.StartsWithSegments("/admin")))
             {
-                ctx.Response.Redirect($"https://{domainCfg.Sub("admin")}/", permanent: false);
+                ctx.Response.Redirect(domainCfg.Url("admin", "/"), permanent: false);
                 return;
             }
             await next();

--- a/DorkNet.Server/Startup/ServiceCollectionExtensions.cs
+++ b/DorkNet.Server/Startup/ServiceCollectionExtensions.cs
@@ -106,7 +106,8 @@ public static class ServiceCollectionExtensions
             builder.Configuration["Domain:Apex"]
             ?? Environment.GetEnvironmentVariable("DORKNET_DOMAIN")
             ?? "localhost";
-        builder.Services.AddSingleton(new DomainConfig(apex));
+        var scheme = builder.Configuration["Domain:Scheme"] ?? "https";
+        builder.Services.AddSingleton(new DomainConfig(apex, scheme));
         builder.Services.Configure<Microsoft.AspNetCore.HostFiltering.HostFilteringOptions>(opt =>
         {
             opt.AllowedHosts = new[] { apex, $"*.{apex}", "localhost", "127.0.0.1" };


### PR DESCRIPTION
## What changed

Fixes #19.

The December server always advertised service URLs with `https://`, including the notification hub URL returned from `/api/notification/hub/v1`. That is wrong for launcher/easy setups that run the server over plain HTTP, and it can send the client to the wrong `/hub/v1/negotiate` URL.

This adds scheme-aware URL building to `DomainConfig` and uses it for:

- the name-server service map
- `api/config/v1/service_urls`
- `api/notification/hub/v1`
- the admin redirect helper

The launcher already passes `Domain__Scheme`, so HTTP deployments now advertise HTTP notification URLs instead of hardcoded HTTPS ones.

## Validation

- `dotnet build DorkNet.Server\DorkNet.Server.csproj`

Build passed with existing nullable/unread-parameter warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced URL construction and scheme support across API endpoints for improved flexibility and consistency.
  * Added configuration option for custom URL schemes (defaults to HTTPS).
  * Refactored service endpoint URL generation to leverage centralized configuration logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->