### PR TITLE
Fix March admin API path in easy mode

### DIFF
--- a/DorkNet.Server/admin-ui/src/lib/api.ts
+++ b/DorkNet.Server/admin-ui/src/lib/api.ts
@@ -1,6 +1,20 @@
 import { clearSession, getToken, notifyAuthChange } from './auth';
 
-const API_BASE = '/api/admin/v1';
+const API_BASE = adminApiBase();
+
+function adminApiBase(): string {
+  if (typeof window === 'undefined') return '/api/admin/v1';
+
+  const marker = '/__dn/admin';
+  const path = window.location.pathname;
+  const lower = path.toLowerCase();
+  const markerAt = lower.indexOf(marker);
+  if (markerAt >= 0) {
+    return path.slice(0, markerAt + marker.length) + '/api/admin/v1';
+  }
+
+  return '/api/admin/v1';
+}
 
 export class ApiError extends Error {
   constructor(public status: number, message: string, public body?: unknown) {


### PR DESCRIPTION
## What changed

Fixes #22.

The March admin panel works on the `admin.<host>` shape, but easy mode can serve it at `https://<host>/__dn/admin/`. The SPA was using an absolute `/api/admin/v1` base, so browser requests skipped the `/__dn/admin` prefix and went to the wrong route.

This keeps the existing subdomain behavior and adds single-origin support by detecting `/__dn/admin` in the current path and sending admin API calls through that same prefix.

## Validation

- `dotnet build DorkNet.Server\DorkNet.Server.csproj`
- `npm ci --no-fund --no-audit --loglevel=error`
- `npm run build` in `DorkNet.Server/admin-ui`

The server build passed with existing warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated admin UI API base path resolution to dynamically compute the endpoint based on the application's deployment environment and routing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->