### PR TITLE
Add DorkNet.Contracts reference to monolith Server build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,12 +53,14 @@ WORKDIR /src
 # DorkNet.Models project ref, so its csproj needs to be present too.
 COPY DorkNet.Server/DorkNet.Server.csproj DorkNet.Server/
 COPY DorkNet.Models/DorkNet.Models.csproj DorkNet.Models/
+COPY DorkNet.Contracts/DorkNet.Contracts.csproj DorkNet.Contracts/
 RUN dotnet restore DorkNet.Server/DorkNet.Server.csproj
 
 # Now copy the rest of the .NET source, then drop the prebuilt admin
 # SPA into wwwroot/admin so the publish step ships it as static content.
 COPY DorkNet.Server/ DorkNet.Server/
 COPY DorkNet.Models/ DorkNet.Models/
+COPY DorkNet.Contracts/ DorkNet.Contracts/
 COPY --from=admin-ui /wwwroot/admin/ DorkNet.Server/wwwroot/admin/
 COPY --from=site      /wwwroot/site/  DorkNet.Server/wwwroot/site/
 

--- a/DorkNet.Server/DorkNet.Server.csproj
+++ b/DorkNet.Server/DorkNet.Server.csproj
@@ -73,6 +73,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DorkNet.Models\DorkNet.Models.csproj" />
+    <ProjectReference Include="..\DorkNet.Contracts\DorkNet.Contracts.csproj" />
   </ItemGroup>
 
   <!-- Service-slice containers reference DorkNet.Server for shared controllers

--- a/docker-compose.microservices.dokploy.yml
+++ b/docker-compose.microservices.dokploy.yml
@@ -17,8 +17,9 @@ x-dorknet-service-env: &dorknet-service-env
 
 x-dorknet-app-networks: &dorknet-app-networks
   networks:
+    # Internal only — backends are reached by the gateway over `default`,
+    # never directly by Traefik, so keep them off dokploy-network.
     - default
-    - dokploy-network
 
 services:
   gateway:
@@ -42,6 +43,18 @@ services:
       DorkNet__Services__Monolith: http://monolith:8080
     expose:
       - "8080"
+    networks:
+      - default
+      - dokploy-network
+    labels:
+      # Cloudflare terminates TLS at the edge; the tunnel -> Traefik leg is
+      # internal HTTP, so route on the `web` entrypoint with no certresolver.
+      - traefik.enable=true
+      - traefik.docker.network=dokploy-network
+      # Scope routing to YOUR domain (apex + subdomains) instead of catch-all:
+      - traefik.http.routers.dorknet-gw.rule=Host(`${DORKNET_DOMAIN}`) || HostRegexp(`^.+\.${DORKNET_DOMAIN}$`)
+      - traefik.http.routers.dorknet-gw.entrypoints=web
+      - traefik.http.services.dorknet-gw.loadbalancer.server.port=8080
     depends_on:
       - identity
       - rooms
@@ -57,6 +70,10 @@ services:
   cloudflared:
     image: cloudflare/cloudflared:latest
     command: tunnel --no-autoupdate run --token ${CLOUDFLARE_TUNNEL_TOKEN:?Set CLOUDFLARE_TUNNEL_TOKEN in Dokploy}
+    # Must share dokploy-network so the tunnel can reach the Traefik
+    # container (dokploy-traefik) by name and hand traffic off to it.
+    networks:
+      - dokploy-network
     depends_on:
       - gateway
     restart: unless-stopped


### PR DESCRIPTION
DorkNet.Server uses
  DorkNetRouteOwnership from DorkNet.Contracts but neither the csproj referenced it nor the Dockerfile copied it, so the monolith image failed to compile (CS0234). Adds the
  project reference and copies the project into the build stage.