### PR TITLE
Whitelist api.{apex} as a shared public host

### DIFF
--- a/DorkNet.Contracts/DorkNetRouteOwnership.cs
+++ b/DorkNet.Contracts/DorkNetRouteOwnership.cs
@@ -167,6 +167,11 @@ public static class DorkNetRouteOwnership
     public static IReadOnlyList<string> PublicSubdomains =>
         ServiceRouteGroups
             .SelectMany(group => group.HostSubdomains)
+            // api.* is a shared public host: it owns no service by host and is
+            // dispatched by path (see ResolvePublicService's path-prefix pass),
+            // so it never appears in a group's HostSubdomains. It must still be
+            // whitelisted here or HostFiltering rejects every api.{apex} request.
+            .Append("api")
             .Append(AdminHost)
             .Append("feed")
             .Distinct(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
## Problem

Deploying the December branch produced `400 Bad Request - Invalid Hostname` for every request to `api.{apex}` (e.g. `api.dork.sh`). Startup log showed `api` absent from the computed allow-list:

`[domain] apex=dork.sh, allowedHosts=[dork.sh, localhost, 127.0.0.1, accounts.dork.sh, admin.dork.sh, ... www.dork.sh]` — every service subdomain **except `api`**.

## Cause

`AddDomain` builds `HostFilteringOptions.AllowedHosts` from `DorkNetRouteOwnership.PublicSubdomains`, which flattens each route group's `HostSubdomains`. `api.{apex}` is the client's primary API host and is dispatched by **path** across every service, so it belongs to no single group's `HostSubdomains` — and was therefore never whitelisted. HostFiltering runs before routing, so the request died at the middleware before reaching any controller.

This wasn't caught in tests because `DorkNetServerFactory` overrides `AllowedHosts` with the `*.{apex}` wildcard, masking the enumerated-list gap.

## Fix

Append `"api"` to `PublicSubdomains` alongside `admin`/`feed`. It is whitelisted while remaining path-routed (it owns no service by host, so `ResolvePublicService` still dispatches `api.*` by path — no change to gateway routing).

Builds verified: `DorkNet.Server` (monolith) and `DorkNet.Gateway`.