### PR TITLE
Migrate June 2018 server auth to Open.IdentityServer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # DorkNet.Server container image — Coolify deploy target.
 # ────────────────────────────────────────────────────────────────────
 # Multi-stage: SDK image builds + publishes, runtime image is the
-# slimmer aspnet:9.0 with only the published output.
+# slimmer aspnet:10.0 with only the published output.
 #
 # Build context: repo root (so Tools/ and DorkNet.Models/ are visible
 # to ProjectReference + dotnet restore). The .dockerignore at the
 # repo root keeps the bin/, obj/, and other dev junk out of the
 # context.
 
-ARG DOTNET_VERSION=9.0
+ARG DOTNET_VERSION=10.0
 ARG NODE_VERSION=20
 
 # ── admin SPA build stage ──────────────────────────────────────────
@@ -76,13 +76,13 @@ WORKDIR /app
 
 # curl + wget for healthcheck probes — Coolify v4 defaults to wget for
 # its own probe regardless of what the image's HEALTHCHECK uses, so
-# both have to be present. The aspnet:9.0 base image strips both by
+# both have to be present. The aspnet:10.0 base image strips both by
 # default to keep the surface area small.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl wget \
     && rm -rf /var/lib/apt/lists/*
 
-# Run as a non-root user — aspnet:9.0 ships with the `app` UID 1654.
+# Run as a non-root user — aspnet:10.0 ships with the `app` UID 1654.
 # Coolify mounts persistent volumes with write permission for this UID.
 USER app
 

--- a/DorkNet.Models/DorkNet.Models.csproj
+++ b/DorkNet.Models/DorkNet.Models.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/DorkNet.Server/Auth/IdentityServerIntegration.cs
+++ b/DorkNet.Server/Auth/IdentityServerIntegration.cs
@@ -67,9 +67,54 @@ public sealed class IdentityServerSigningKeyProvider
     private static X509Certificate2 LoadCertificateFromBase64(string certificateBase64, string password)
     {
         var flags = X509KeyStorageFlags.UserKeySet | X509KeyStorageFlags.Exportable;
-        var compact = new string(certificateBase64.Where(c => !char.IsWhiteSpace(c)).ToArray());
-        var bytes = Convert.FromBase64String(compact);
+        var compact = NormalizeCertificateBase64(certificateBase64);
+        byte[] bytes;
+        try
+        {
+            bytes = Convert.FromBase64String(compact);
+        }
+        catch (FormatException ex)
+        {
+            throw new InvalidOperationException(
+                "IdentityServer signing certificate base64 is invalid. " +
+                "Set IdentityServer__SigningCertificateBase64 to the PFX bytes encoded as base64, " +
+                "without a file path or shell assignment text.",
+                ex);
+        }
         return new X509Certificate2(bytes, password, flags);
+    }
+
+    private static string NormalizeCertificateBase64(string value)
+    {
+        var text = value.Trim().Trim('"', '\'');
+        var equals = text.IndexOf('=');
+        if (equals > 0)
+        {
+            var key = text[..equals].Trim();
+            if (key.Equals("IdentityServer__SigningCertificateBase64", StringComparison.OrdinalIgnoreCase) ||
+                key.Equals("IdentityServer:SigningCertificateBase64", StringComparison.OrdinalIgnoreCase))
+                text = text[(equals + 1)..].Trim().Trim('"', '\'');
+        }
+
+        if (text.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+        {
+            var comma = text.IndexOf(',');
+            if (comma >= 0)
+                text = text[(comma + 1)..];
+        }
+
+        if (text.StartsWith("base64:", StringComparison.OrdinalIgnoreCase))
+            text = text["base64:".Length..];
+
+        var compact = new string(text.Where(c => !char.IsWhiteSpace(c)).ToArray())
+            .Replace('-', '+')
+            .Replace('_', '/');
+        return (compact.Length % 4) switch
+        {
+            2 => compact + "==",
+            3 => compact + "=",
+            _ => compact,
+        };
     }
 
     private static X509Certificate2 LoadOrCreateCertificate(string path, string password)

--- a/DorkNet.Server/Auth/IdentityServerIntegration.cs
+++ b/DorkNet.Server/Auth/IdentityServerIntegration.cs
@@ -203,6 +203,27 @@ public sealed class IdentityServerLegacyTokenRequestMiddleware(RequestDelegate n
             changed = true;
         }
 
+        if (IsDevicePasswordGrant(values))
+        {
+            if (!values.ContainsKey("username") || string.IsNullOrWhiteSpace(values["username"].ToString()))
+            {
+                values["username"] = First(
+                    values.TryGetValue("deviceId", out var deviceId) ? deviceId.ToString() : null,
+                    values.TryGetValue("device_id", out var deviceIdSnake) ? deviceIdSnake.ToString() : null,
+                    values.TryGetValue("platformId", out var platformId) ? platformId.ToString() : null,
+                    values.TryGetValue("platform_id", out var platformIdSnake) ? platformIdSnake.ToString() : null,
+                    "anonymous");
+                changed = true;
+            }
+
+            if (!values.ContainsKey("password") || string.IsNullOrWhiteSpace(values["password"].ToString()))
+            {
+                values["password"] = "__dorknet_device_login__";
+                values["dorknet_device_login"] = "true";
+                changed = true;
+            }
+        }
+
         var scopes = values.TryGetValue("scope", out var rawScope)
             ? rawScope.ToString()
             : string.Empty;
@@ -223,6 +244,18 @@ public sealed class IdentityServerLegacyTokenRequestMiddleware(RequestDelegate n
         HttpMethods.IsPost(context.Request.Method)
         && context.Request.Path.Equals("/connect/token", StringComparison.OrdinalIgnoreCase)
         && context.Request.HasFormContentType;
+
+    private static bool IsDevicePasswordGrant(Dictionary<string, StringValues> values)
+    {
+        if (!values.TryGetValue("grant_type", out var grantType) ||
+            !string.Equals(grantType.ToString(), GrantType.ResourceOwnerPassword, StringComparison.OrdinalIgnoreCase))
+            return false;
+        return !values.TryGetValue("password", out var password) ||
+               string.IsNullOrWhiteSpace(password.ToString());
+    }
+
+    private static string First(params string?[] values) =>
+        values.FirstOrDefault(v => !string.IsNullOrWhiteSpace(v)) ?? "anonymous";
 
     private static string MergeScopes(string existing)
     {
@@ -358,8 +391,9 @@ public sealed class RecRoomPasswordValidator(
         var deviceId = First(raw.Get("deviceId"), raw.Get("device_id"));
         var platformId = First(raw.Get("platformId"), raw.Get("platform_id"));
         var platform = int.TryParse(raw.Get("platform"), out var p) ? p : 0;
+        var deviceLogin = string.Equals(raw.Get("dorknet_device_login"), "true", StringComparison.OrdinalIgnoreCase);
 
-        if (!string.IsNullOrEmpty(context.Password) && !string.IsNullOrEmpty(context.UserName))
+        if (!deviceLogin && !string.IsNullOrEmpty(context.Password) && !string.IsNullOrEmpty(context.UserName))
         {
             var byName = await playerService.GetByUsernameAsync(context.UserName);
             if (byName is null || byName.PasswordHash is null)

--- a/DorkNet.Server/Auth/IdentityServerIntegration.cs
+++ b/DorkNet.Server/Auth/IdentityServerIntegration.cs
@@ -1,0 +1,556 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Text.Json;
+using Duende.IdentityServer;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Validation;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Primitives;
+using Microsoft.IdentityModel.Tokens;
+using DorkNet.Server.Data;
+using DorkNet.Server.Data.Entities;
+using DorkNet.Server.Services;
+
+namespace DorkNet.Server.Auth;
+
+public sealed class IdentityServerSigningKeyProvider
+{
+    private readonly string _legacySecret;
+
+    public IdentityServerSigningKeyProvider(IConfiguration config)
+    {
+        _legacySecret =
+            Environment.GetEnvironmentVariable("DORKNET_JWT_SECRET")
+            ?? Environment.GetEnvironmentVariable("RECNET_JWT_SECRET")
+            ?? config["Jwt:Secret"]
+            ?? throw new InvalidOperationException(
+                "JWT secret not configured. Set DORKNET_JWT_SECRET env var or Jwt:Secret in appsettings.Local.json.");
+
+        CertificatePath = ResolveCertificatePath(config);
+        Certificate = LoadOrCreateCertificate(CertificatePath, config, _legacySecret);
+        SigningKey = new X509SecurityKey(Certificate);
+        LegacyJwtKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_legacySecret));
+    }
+
+    public string CertificatePath { get; }
+    public X509Certificate2 Certificate { get; }
+    public SecurityKey SigningKey { get; }
+    public SecurityKey LegacyJwtKey { get; }
+    public SecurityKey[] ValidationKeys => new[] { SigningKey, LegacyJwtKey };
+
+    private static string ResolveCertificatePath(IConfiguration config)
+    {
+        var path = config["IdentityServer:SigningCertificatePath"];
+        if (string.IsNullOrWhiteSpace(path))
+            path = Path.Combine(AppContext.BaseDirectory, "data", "identityserver-signing.pfx");
+        return path;
+    }
+
+    private static X509Certificate2 LoadOrCreateCertificate(string path, IConfiguration config, string fallbackPassword)
+    {
+        var password = config["IdentityServer:SigningCertificatePassword"] ?? fallbackPassword;
+        var flags = X509KeyStorageFlags.UserKeySet | X509KeyStorageFlags.Exportable;
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+        if (File.Exists(path))
+            return new X509Certificate2(path, password, flags);
+
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            "CN=DorkNet IdentityServer Signing",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        request.CertificateExtensions.Add(
+            new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, critical: false));
+
+        using var created = request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddYears(10));
+        var bytes = created.Export(X509ContentType.Pfx, password);
+        File.WriteAllBytes(path, bytes);
+        return new X509Certificate2(bytes, password, flags);
+    }
+}
+
+public static class RecRoomIdentityServerRegistration
+{
+    public static void AddRecRoomIdentityServer(
+        this IServiceCollection services,
+        IConfiguration config,
+        DomainConfig domain,
+        IdentityServerSigningKeyProvider signingKeyProvider)
+    {
+        services
+            .AddIdentityServer(options =>
+            {
+                options.IssuerUri = domain.AuthIssuer.TrimEnd('/');
+                options.KeyManagement.Enabled = false;
+                var licenseKey =
+                    Environment.GetEnvironmentVariable("DUENDE_IDENTITYSERVER_LICENSE_KEY")
+                    ?? config["IdentityServer:LicenseKey"];
+                if (!string.IsNullOrWhiteSpace(licenseKey))
+                    options.LicenseKey = licenseKey;
+            })
+            .AddInMemoryIdentityResources(RecRoomIdentityServerConfig.IdentityResources)
+            .AddInMemoryApiScopes(RecRoomIdentityServerConfig.ApiScopes)
+            .AddInMemoryClients(RecRoomIdentityServerConfig.Clients)
+            .AddSigningCredential(signingKeyProvider.SigningKey, SecurityAlgorithms.RsaSha256)
+            .AddResourceOwnerValidator<RecRoomPasswordValidator>()
+            .AddExtensionGrantValidator<CachedLoginGrantValidator>()
+            .AddProfileService<RecRoomProfileService>();
+    }
+}
+
+internal static class RecRoomIdentityServerConfig
+{
+    public const string ClientId = "recroom.client";
+    public const string GameClientScope = "gameClient";
+    public const string CachedLoginGrantType = "cached_login";
+
+    public static readonly IdentityResource[] IdentityResources =
+    {
+        new IdentityResources.OpenId(),
+        new IdentityResources.Profile(),
+    };
+
+    public static readonly ApiScope[] ApiScopes =
+    {
+        new(GameClientScope, "Game client")
+        {
+            UserClaims = RecRoomIdentityClaims.UserClaimTypes,
+        },
+        new("api", "DorkNet API")
+        {
+            UserClaims = RecRoomIdentityClaims.UserClaimTypes,
+        },
+    };
+
+    public static readonly Client[] Clients =
+    {
+        new()
+        {
+            ClientId = ClientId,
+            ClientName = "Rec Room Client",
+            RequireClientSecret = false,
+            AllowedGrantTypes = { GrantType.ResourceOwnerPassword, CachedLoginGrantType },
+            AllowedScopes =
+            {
+                IdentityServerConstants.StandardScopes.OpenId,
+                IdentityServerConstants.StandardScopes.Profile,
+                IdentityServerConstants.StandardScopes.OfflineAccess,
+                GameClientScope,
+                "api",
+            },
+            AllowOfflineAccess = true,
+            AccessTokenLifetime = 60 * 60 * 12,
+            AbsoluteRefreshTokenLifetime = 60 * 60 * 24 * 30,
+            SlidingRefreshTokenLifetime = 60 * 60 * 24 * 30,
+            RefreshTokenUsage = TokenUsage.ReUse,
+            RefreshTokenExpiration = TokenExpiration.Absolute,
+            UpdateAccessTokenClaimsOnRefresh = true,
+            AlwaysIncludeUserClaimsInIdToken = true,
+        },
+    };
+}
+
+public sealed class IdentityServerLegacyTokenRequestMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!IsTokenRequest(context))
+        {
+            await next(context);
+            return;
+        }
+
+        var form = await context.Request.ReadFormAsync();
+        var values = form.ToDictionary(
+            kvp => kvp.Key,
+            kvp => kvp.Value,
+            StringComparer.OrdinalIgnoreCase);
+        var changed = false;
+
+        if (!values.ContainsKey("client_id"))
+        {
+            values["client_id"] = RecRoomIdentityServerConfig.ClientId;
+            changed = true;
+        }
+
+        var scopes = values.TryGetValue("scope", out var rawScope)
+            ? rawScope.ToString()
+            : string.Empty;
+        var mergedScopes = MergeScopes(scopes);
+        if (!string.Equals(scopes, mergedScopes, StringComparison.Ordinal))
+        {
+            values["scope"] = mergedScopes;
+            changed = true;
+        }
+
+        if (changed)
+            context.Features.Set<IFormFeature>(new FormFeature(new FormCollection(values)));
+
+        await next(context);
+    }
+
+    private static bool IsTokenRequest(HttpContext context) =>
+        HttpMethods.IsPost(context.Request.Method)
+        && context.Request.Path.Equals("/connect/token", StringComparison.OrdinalIgnoreCase)
+        && context.Request.HasFormContentType;
+
+    private static string MergeScopes(string existing)
+    {
+        var scopes = existing
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        scopes.Add(IdentityServerConstants.StandardScopes.OpenId);
+        scopes.Add(IdentityServerConstants.StandardScopes.Profile);
+        scopes.Add(IdentityServerConstants.StandardScopes.OfflineAccess);
+        scopes.Add(RecRoomIdentityServerConfig.GameClientScope);
+        return string.Join(' ', scopes);
+    }
+}
+
+public sealed class IdentityServerTokenResponseMiddleware(RequestDelegate next, DomainConfig domain)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!IsTokenRequest(context))
+        {
+            await next(context);
+            return;
+        }
+
+        var originalBody = context.Response.Body;
+        await using var buffer = new MemoryStream();
+        context.Response.Body = buffer;
+
+        await next(context);
+
+        context.Response.Body = originalBody;
+        buffer.Position = 0;
+
+        if (context.Response.StatusCode != StatusCodes.Status200OK ||
+            !IsJson(context.Response.ContentType))
+        {
+            await buffer.CopyToAsync(originalBody);
+            return;
+        }
+
+        using var document = await JsonDocument.ParseAsync(buffer);
+        var response = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var property in document.RootElement.EnumerateObject())
+            response[property.Name] = ConvertJsonValue(property.Value);
+
+        if (response.TryGetValue("access_token", out var accessValue) &&
+            accessValue is string accessToken &&
+            !string.IsNullOrWhiteSpace(accessToken))
+        {
+            AddLegacyTokenAliases(response, accessToken);
+            SetAccessCookie(context, accessToken);
+        }
+
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(response);
+        context.Response.ContentLength = bytes.Length;
+        context.Response.ContentType = "application/json; charset=utf-8";
+        await originalBody.WriteAsync(bytes);
+    }
+
+    private static bool IsTokenRequest(HttpContext context) =>
+        HttpMethods.IsPost(context.Request.Method)
+        && context.Request.Path.Equals("/connect/token", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsJson(string? contentType) =>
+        contentType?.StartsWith("application/json", StringComparison.OrdinalIgnoreCase) == true;
+
+    private static object? ConvertJsonValue(JsonElement value) =>
+        value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString(),
+            JsonValueKind.Number when value.TryGetInt64(out var l) => l,
+            JsonValueKind.Number => value.GetDouble(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Null => null,
+            _ => JsonSerializer.Deserialize<object>(value.GetRawText()),
+        };
+
+    private static void AddLegacyTokenAliases(Dictionary<string, object?> response, string accessToken)
+    {
+        response["Access_token"] = accessToken;
+        response["accessToken"] = accessToken;
+        response["AccessToken"] = accessToken;
+        response["token"] = accessToken;
+        response["Token"] = accessToken;
+        response["tokenType"] = "Bearer";
+        response["TokenType"] = "Bearer";
+
+        if (response.TryGetValue("expires_in", out var expiresIn))
+        {
+            response["expiresIn"] = expiresIn;
+            response["ExpiresIn"] = expiresIn;
+        }
+
+        if (response.TryGetValue("refresh_token", out var refreshToken))
+        {
+            response["Refresh_token"] = refreshToken;
+            response["refreshToken"] = refreshToken;
+            response["RefreshToken"] = refreshToken;
+        }
+
+        var signingKey = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+        response["key"] = signingKey;
+        response["Key"] = signingKey;
+    }
+
+    private void SetAccessCookie(HttpContext context, string accessToken)
+    {
+        var cookie = new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = string.Equals(domain.Scheme, "https", StringComparison.OrdinalIgnoreCase),
+            SameSite = SameSiteMode.None,
+            Expires = DateTimeOffset.UtcNow.AddHours(12),
+            IsEssential = true,
+        };
+        if (domain.Apex.Contains('.'))
+            cookie.Domain = "." + domain.Apex;
+        context.Response.Cookies.Append(AuthService.AccessCookieName, accessToken, cookie);
+    }
+}
+
+public sealed class RecRoomPasswordValidator(
+    PlayerService playerService,
+    LevelService level,
+    ServerSettingsService settings,
+    DorkNetDbContext db,
+    ILogger<RecRoomPasswordValidator> logger) : IResourceOwnerPasswordValidator
+{
+    public async Task ValidateAsync(ResourceOwnerPasswordValidationContext context)
+    {
+        var raw = context.Request.Raw;
+        var deviceId = First(raw.Get("deviceId"), raw.Get("device_id"));
+        var platformId = First(raw.Get("platformId"), raw.Get("platform_id"));
+        var platform = int.TryParse(raw.Get("platform"), out var p) ? p : 0;
+
+        if (!string.IsNullOrEmpty(context.Password) && !string.IsNullOrEmpty(context.UserName))
+        {
+            var byName = await playerService.GetByUsernameAsync(context.UserName);
+            if (byName is null || byName.PasswordHash is null)
+            {
+                context.Result = new GrantValidationResult(
+                    TokenRequestErrors.InvalidGrant,
+                    "unknown_user_or_no_password");
+                return;
+            }
+
+            if (!BCrypt.Net.BCrypt.Verify(context.Password, byName.PasswordHash))
+            {
+                context.Result = new GrantValidationResult(
+                    TokenRequestErrors.InvalidGrant,
+                    "password_mismatch");
+                return;
+            }
+
+            await playerService.TagPlatformAsync(byName.Id, platform, platformId);
+            await TryAwardLoginXpAsync(byName.Id);
+            context.Result = await CreateSuccessAsync(byName, "password");
+            return;
+        }
+
+        var effectiveDeviceId = !string.IsNullOrWhiteSpace(deviceId)
+            ? deviceId
+            : $"legacy-{(context.UserName ?? "anonymous").ToLowerInvariant()}";
+
+        if (await settings.AreSignupsDisabledAsync())
+        {
+            var existing = await playerService.GetByDeviceAsync(effectiveDeviceId);
+            if (existing is null)
+            {
+                logger.LogInformation(
+                    "[auth] IdentityServer password grant device fallback refused - signups disabled (device={Device})",
+                    effectiveDeviceId);
+                context.Result = new GrantValidationResult(
+                    TokenRequestErrors.InvalidGrant,
+                    "signups_disabled");
+                return;
+            }
+        }
+
+        var player = await playerService.GetOrCreateByDeviceAsync(
+            deviceId: effectiveDeviceId,
+            platform: platform,
+            platformId: platformId,
+            displayName: context.UserName);
+        await TryAwardLoginXpAsync(player.Id);
+        context.Result = await CreateSuccessAsync(player, "device_password");
+    }
+
+    private async Task<GrantValidationResult> CreateSuccessAsync(PlayerEntity player, string authMethod) =>
+        new(
+            subject: player.Id.ToString(),
+            authenticationMethod: authMethod,
+            claims: await RecRoomIdentityClaims.CreateAsync(db, player.Id, player.Username));
+
+    private async Task TryAwardLoginXpAsync(long playerId)
+    {
+        var lastSeen = await db.Players
+            .Where(p => p.Id == playerId)
+            .Select(p => p.LastSeenAt)
+            .FirstOrDefaultAsync();
+        if (lastSeen.Date < DateTime.UtcNow.Date)
+            await level.AwardXpAsync(playerId, LevelService.FirstLoginXp, "first_login_today");
+    }
+
+    private static string? First(params string?[] values) =>
+        values.FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
+}
+
+public sealed class CachedLoginGrantValidator(
+    PlayerService playerService,
+    LevelService level,
+    OrphanAccountTracker orphans,
+    DorkNetDbContext db,
+    ILogger<CachedLoginGrantValidator> logger) : IExtensionGrantValidator
+{
+    public string GrantType => RecRoomIdentityServerConfig.CachedLoginGrantType;
+
+    public async Task ValidateAsync(ExtensionGrantValidationContext context)
+    {
+        var raw = context.Request.Raw;
+        if (!long.TryParse(raw.Get("account_id"), out var pickedId))
+        {
+            context.Result = new GrantValidationResult(
+                TokenRequestErrors.InvalidGrant,
+                "missing account_id");
+            return;
+        }
+
+        var picked = await playerService.GetByIdAsync(pickedId);
+        if (picked is null)
+        {
+            context.Result = new GrantValidationResult(
+                TokenRequestErrors.InvalidGrant,
+                "unknown account_id");
+            return;
+        }
+
+        var deviceId = First(raw.Get("deviceId"), raw.Get("device_id"));
+        var platformId = First(raw.Get("platformId"), raw.Get("platform_id"));
+        var platform = int.TryParse(raw.Get("platform"), out var p) ? p : 0;
+
+        var pendingId = orphans.PeekPending(deviceId, platformId);
+        if (pendingId is long orphanId && orphanId != pickedId)
+        {
+            await playerService.DeleteOrphanAsync(orphanId);
+            logger.LogInformation(
+                "[orphan-cleanup] cached_login picked {PickedId}; deleted just-created {OrphanId}",
+                pickedId,
+                orphanId);
+        }
+        orphans.Clear(deviceId, platformId);
+
+        await TryAwardLoginXpAsync(picked.Id);
+        await playerService.TagPlatformAsync(picked.Id, platform, platformId);
+        context.Result = new GrantValidationResult(
+            subject: picked.Id.ToString(),
+            authenticationMethod: GrantType,
+            claims: await RecRoomIdentityClaims.CreateAsync(db, picked.Id, picked.Username));
+    }
+
+    private async Task TryAwardLoginXpAsync(long playerId)
+    {
+        var lastSeen = await db.Players
+            .Where(p => p.Id == playerId)
+            .Select(p => p.LastSeenAt)
+            .FirstOrDefaultAsync();
+        if (lastSeen.Date < DateTime.UtcNow.Date)
+            await level.AwardXpAsync(playerId, LevelService.FirstLoginXp, "first_login_today");
+    }
+
+    private static string? First(params string?[] values) =>
+        values.FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
+}
+
+public sealed class RecRoomProfileService(PlayerService playerService, DorkNetDbContext db) : IProfileService
+{
+    public async Task GetProfileDataAsync(ProfileDataRequestContext context)
+    {
+        if (!TryGetSubjectId(context.Subject, out var playerId))
+            return;
+
+        var player = await playerService.GetByIdAsync(playerId);
+        if (player is null)
+            return;
+
+        context.IssuedClaims.AddRange(
+            await RecRoomIdentityClaims.CreateAsync(db, player.Id, player.Username));
+    }
+
+    public async Task IsActiveAsync(IsActiveContext context)
+    {
+        context.IsActive =
+            TryGetSubjectId(context.Subject, out var playerId)
+            && await playerService.GetByIdAsync(playerId) is not null;
+    }
+
+    private static bool TryGetSubjectId(ClaimsPrincipal subject, out long playerId)
+    {
+        var value = subject.FindFirstValue(JwtRegisteredClaimNames.Sub)
+            ?? subject.FindFirstValue(ClaimTypes.NameIdentifier);
+        return long.TryParse(value, out playerId);
+    }
+}
+
+public static class RecRoomIdentityClaims
+{
+    public static readonly List<string> UserClaimTypes =
+    [
+        JwtRegisteredClaimNames.Sub,
+        ClaimTypes.NameIdentifier,
+        "name",
+        "role",
+        ClaimTypes.Role,
+        "roles",
+        "accountId",
+        "account_id",
+        "accountid",
+    ];
+
+    public static async Task<List<Claim>> CreateAsync(DorkNetDbContext db, long playerId, string? username = null)
+    {
+        var playerInfo = await db.Players
+            .Where(p => p.Id == playerId)
+            .Select(p => new { p.Username, IsDev = p.IsDeveloper || p.IsAdmin })
+            .FirstOrDefaultAsync();
+        var name = username ?? playerInfo?.Username ?? playerId.ToString();
+        var isDev = playerInfo?.IsDev ?? false;
+
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, playerId.ToString()),
+            new(JwtRegisteredClaimNames.Sub, playerId.ToString()),
+            new("name", name),
+            new("accountId", playerId.ToString()),
+            new("account_id", playerId.ToString()),
+            new("accountid", playerId.ToString()),
+            new(ClaimTypes.Role, "gameClient"),
+            new("role", "gameClient"),
+            new("roles", "gameClient"),
+        };
+
+        if (isDev)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, "developer"));
+            claims.Add(new Claim("role", "developer"));
+            claims.Add(new Claim("roles", "developer"));
+        }
+
+        return claims;
+    }
+}

--- a/DorkNet.Server/Auth/IdentityServerIntegration.cs
+++ b/DorkNet.Server/Auth/IdentityServerIntegration.cs
@@ -3,10 +3,10 @@ using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
-using Duende.IdentityServer;
-using Duende.IdentityServer.Models;
-using Duende.IdentityServer.Services;
-using Duende.IdentityServer.Validation;
+using Open.IdentityServer;
+using Open.IdentityServer.Models;
+using Open.IdentityServer.Services;
+using Open.IdentityServer.Validation;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Primitives;
@@ -206,12 +206,6 @@ public static class RecRoomIdentityServerRegistration
             .AddIdentityServer(options =>
             {
                 options.IssuerUri = domain.AuthIssuer.TrimEnd('/');
-                options.KeyManagement.Enabled = false;
-                var licenseKey =
-                    Environment.GetEnvironmentVariable("DUENDE_IDENTITYSERVER_LICENSE_KEY")
-                    ?? config["IdentityServer:LicenseKey"];
-                if (!string.IsNullOrWhiteSpace(licenseKey))
-                    options.LicenseKey = licenseKey;
             })
             .AddInMemoryIdentityResources(RecRoomIdentityServerConfig.IdentityResources)
             .AddInMemoryApiScopes(RecRoomIdentityServerConfig.ApiScopes)
@@ -256,7 +250,7 @@ internal static class RecRoomIdentityServerConfig
             ClientName = "Rec Room game client",
             RequireClientSecret = true,
             ClientSecrets = { new Secret(ClientSecret.Sha256()) },
-            AllowedGrantTypes = { GrantType.ResourceOwnerPassword, GrantType.RefreshToken, CachedLoginGrantType },
+            AllowedGrantTypes = { GrantType.ResourceOwnerPassword, "refresh_token", CachedLoginGrantType },
             AllowedScopes = RecRoomScopes(),
             AllowOfflineAccess = true,
             AccessTokenLifetime = 60 * 60 * 12,

--- a/DorkNet.Server/Auth/IdentityServerIntegration.cs
+++ b/DorkNet.Server/Auth/IdentityServerIntegration.cs
@@ -81,7 +81,58 @@ public sealed class IdentityServerSigningKeyProvider
                 "without a file path or shell assignment text.",
                 ex);
         }
-        return new X509Certificate2(bytes, password, flags);
+        try
+        {
+            return new X509Certificate2(bytes, password, flags);
+        }
+        catch (CryptographicException ex)
+        {
+            if (TryLoadPemCertificate(bytes, password, flags, out var certificate))
+                return certificate;
+
+            throw new InvalidOperationException(
+                "IdentityServer signing certificate base64 decoded successfully, but it is not a valid PFX/PKCS#12 certificate. " +
+                "Set IdentityServer__SigningCertificateBase64 to the PFX bytes encoded as base64 and make sure " +
+                "IdentityServer__SigningCertificatePassword matches the PFX password.",
+                ex);
+        }
+    }
+
+    private static bool TryLoadPemCertificate(
+        byte[] bytes,
+        string password,
+        X509KeyStorageFlags flags,
+        out X509Certificate2 certificate)
+    {
+        certificate = null!;
+
+        string pem;
+        try
+        {
+            pem = Encoding.UTF8.GetString(bytes);
+        }
+        catch (DecoderFallbackException)
+        {
+            return false;
+        }
+
+        if (!pem.Contains("-----BEGIN", StringComparison.Ordinal))
+            return false;
+
+        try
+        {
+            using var pemCertificate = X509Certificate2.CreateFromPem(pem, pem);
+            if (!pemCertificate.HasPrivateKey)
+                return false;
+
+            var pfxBytes = pemCertificate.Export(X509ContentType.Pfx, password);
+            certificate = new X509Certificate2(pfxBytes, password, flags);
+            return true;
+        }
+        catch (CryptographicException)
+        {
+            return false;
+        }
     }
 
     private static string NormalizeCertificateBase64(string value)

--- a/DorkNet.Server/Auth/IdentityServerIntegration.cs
+++ b/DorkNet.Server/Auth/IdentityServerIntegration.cs
@@ -131,6 +131,8 @@ public static class RecRoomIdentityServerRegistration
 internal static class RecRoomIdentityServerConfig
 {
     public const string ClientId = "recroom.client";
+    public const string NativeClientId = "recroom";
+    public const string NativeClientSecret = "VxZ53kgbbEaRoZAeMe00MagtgD12GLL2";
     public const string GameClientScope = "gameClient";
     public const string CachedLoginGrantType = "cached_login";
 
@@ -157,17 +159,27 @@ internal static class RecRoomIdentityServerConfig
         new()
         {
             ClientId = ClientId,
-            ClientName = "Rec Room Client",
+            ClientName = "Rec Room compatibility client",
             RequireClientSecret = false,
-            AllowedGrantTypes = { GrantType.ResourceOwnerPassword, CachedLoginGrantType },
-            AllowedScopes =
-            {
-                IdentityServerConstants.StandardScopes.OpenId,
-                IdentityServerConstants.StandardScopes.Profile,
-                IdentityServerConstants.StandardScopes.OfflineAccess,
-                GameClientScope,
-                "api",
-            },
+            AllowedGrantTypes = { GrantType.ResourceOwnerPassword, GrantType.RefreshToken, CachedLoginGrantType },
+            AllowedScopes = RecRoomScopes(),
+            AllowOfflineAccess = true,
+            AccessTokenLifetime = 60 * 60 * 12,
+            AbsoluteRefreshTokenLifetime = 60 * 60 * 24 * 30,
+            SlidingRefreshTokenLifetime = 60 * 60 * 24 * 30,
+            RefreshTokenUsage = TokenUsage.ReUse,
+            RefreshTokenExpiration = TokenExpiration.Absolute,
+            UpdateAccessTokenClaimsOnRefresh = true,
+            AlwaysIncludeUserClaimsInIdToken = true,
+        },
+        new()
+        {
+            ClientId = NativeClientId,
+            ClientName = "Rec Room native client",
+            RequireClientSecret = true,
+            ClientSecrets = { new Secret(NativeClientSecret.Sha256()) },
+            AllowedGrantTypes = { GrantType.ResourceOwnerPassword, GrantType.RefreshToken, CachedLoginGrantType },
+            AllowedScopes = RecRoomScopes(),
             AllowOfflineAccess = true,
             AccessTokenLifetime = 60 * 60 * 12,
             AbsoluteRefreshTokenLifetime = 60 * 60 * 24 * 30,
@@ -178,6 +190,15 @@ internal static class RecRoomIdentityServerConfig
             AlwaysIncludeUserClaimsInIdToken = true,
         },
     };
+
+    private static ICollection<string> RecRoomScopes() =>
+    [
+        IdentityServerConstants.StandardScopes.OpenId,
+        IdentityServerConstants.StandardScopes.Profile,
+        IdentityServerConstants.StandardScopes.OfflineAccess,
+        GameClientScope,
+        "api",
+    ];
 }
 
 public sealed class IdentityServerLegacyTokenRequestMiddleware(RequestDelegate next)

--- a/DorkNet.Server/Auth/IdentityServerIntegration.cs
+++ b/DorkNet.Server/Auth/IdentityServerIntegration.cs
@@ -32,12 +32,26 @@ public sealed class IdentityServerSigningKeyProvider
                 "JWT secret not configured. Set DORKNET_JWT_SECRET env var or Jwt:Secret in appsettings.Local.json.");
 
         CertificatePath = ResolveCertificatePath(config);
-        Certificate = LoadOrCreateCertificate(CertificatePath, config, _legacySecret);
+        var password = config["IdentityServer:SigningCertificatePassword"] ?? _legacySecret;
+        var certificateBase64 = config["IdentityServer:SigningCertificateBase64"];
+        if (!string.IsNullOrWhiteSpace(certificateBase64))
+        {
+            LoadedFromBase64 = true;
+            Certificate = LoadCertificateFromBase64(certificateBase64, password);
+        }
+        else
+        {
+            Certificate = LoadOrCreateCertificate(CertificatePath, password);
+        }
         SigningKey = new X509SecurityKey(Certificate);
         LegacyJwtKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_legacySecret));
     }
 
     public string CertificatePath { get; }
+    public bool LoadedFromBase64 { get; }
+    public string CertificateSource => LoadedFromBase64
+        ? "IdentityServer:SigningCertificateBase64"
+        : CertificatePath;
     public X509Certificate2 Certificate { get; }
     public SecurityKey SigningKey { get; }
     public SecurityKey LegacyJwtKey { get; }
@@ -51,9 +65,16 @@ public sealed class IdentityServerSigningKeyProvider
         return path;
     }
 
-    private static X509Certificate2 LoadOrCreateCertificate(string path, IConfiguration config, string fallbackPassword)
+    private static X509Certificate2 LoadCertificateFromBase64(string certificateBase64, string password)
     {
-        var password = config["IdentityServer:SigningCertificatePassword"] ?? fallbackPassword;
+        var flags = X509KeyStorageFlags.UserKeySet | X509KeyStorageFlags.Exportable;
+        var compact = new string(certificateBase64.Where(c => !char.IsWhiteSpace(c)).ToArray());
+        var bytes = Convert.FromBase64String(compact);
+        return new X509Certificate2(bytes, password, flags);
+    }
+
+    private static X509Certificate2 LoadOrCreateCertificate(string path, string password)
+    {
         var flags = X509KeyStorageFlags.UserKeySet | X509KeyStorageFlags.Exportable;
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
 

--- a/DorkNet.Server/Auth/IdentityServerIntegration.cs
+++ b/DorkNet.Server/Auth/IdentityServerIntegration.cs
@@ -3,7 +3,6 @@ using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
-using System.Text.Json;
 using Duende.IdentityServer;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
@@ -130,9 +129,8 @@ public static class RecRoomIdentityServerRegistration
 
 internal static class RecRoomIdentityServerConfig
 {
-    public const string ClientId = "recroom.client";
-    public const string NativeClientId = "recroom";
-    public const string NativeClientSecret = "VxZ53kgbbEaRoZAeMe00MagtgD12GLL2";
+    public const string ClientId = "recroom";
+    public const string ClientSecret = "VxZ53kgbbEaRoZAeMe00MagtgD12GLL2";
     public const string GameClientScope = "gameClient";
     public const string CachedLoginGrantType = "cached_login";
 
@@ -159,25 +157,9 @@ internal static class RecRoomIdentityServerConfig
         new()
         {
             ClientId = ClientId,
-            ClientName = "Rec Room compatibility client",
-            RequireClientSecret = false,
-            AllowedGrantTypes = { GrantType.ResourceOwnerPassword, GrantType.RefreshToken, CachedLoginGrantType },
-            AllowedScopes = RecRoomScopes(),
-            AllowOfflineAccess = true,
-            AccessTokenLifetime = 60 * 60 * 12,
-            AbsoluteRefreshTokenLifetime = 60 * 60 * 24 * 30,
-            SlidingRefreshTokenLifetime = 60 * 60 * 24 * 30,
-            RefreshTokenUsage = TokenUsage.ReUse,
-            RefreshTokenExpiration = TokenExpiration.Absolute,
-            UpdateAccessTokenClaimsOnRefresh = true,
-            AlwaysIncludeUserClaimsInIdToken = true,
-        },
-        new()
-        {
-            ClientId = NativeClientId,
-            ClientName = "Rec Room native client",
+            ClientName = "Rec Room game client",
             RequireClientSecret = true,
-            ClientSecrets = { new Secret(NativeClientSecret.Sha256()) },
+            ClientSecrets = { new Secret(ClientSecret.Sha256()) },
             AllowedGrantTypes = { GrantType.ResourceOwnerPassword, GrantType.RefreshToken, CachedLoginGrantType },
             AllowedScopes = RecRoomScopes(),
             AllowOfflineAccess = true,
@@ -201,7 +183,7 @@ internal static class RecRoomIdentityServerConfig
     ];
 }
 
-public sealed class IdentityServerLegacyTokenRequestMiddleware(RequestDelegate next)
+public sealed class IdentityServerGameTokenRequestMiddleware(RequestDelegate next)
 {
     public async Task InvokeAsync(HttpContext context)
     {
@@ -217,12 +199,6 @@ public sealed class IdentityServerLegacyTokenRequestMiddleware(RequestDelegate n
             kvp => kvp.Value,
             StringComparer.OrdinalIgnoreCase);
         var changed = false;
-
-        if (!values.ContainsKey("client_id"))
-        {
-            values["client_id"] = RecRoomIdentityServerConfig.ClientId;
-            changed = true;
-        }
 
         if (IsDevicePasswordGrant(values))
         {
@@ -288,114 +264,6 @@ public sealed class IdentityServerLegacyTokenRequestMiddleware(RequestDelegate n
         scopes.Add(IdentityServerConstants.StandardScopes.OfflineAccess);
         scopes.Add(RecRoomIdentityServerConfig.GameClientScope);
         return string.Join(' ', scopes);
-    }
-}
-
-public sealed class IdentityServerTokenResponseMiddleware(RequestDelegate next, DomainConfig domain)
-{
-    public async Task InvokeAsync(HttpContext context)
-    {
-        if (!IsTokenRequest(context))
-        {
-            await next(context);
-            return;
-        }
-
-        var originalBody = context.Response.Body;
-        await using var buffer = new MemoryStream();
-        context.Response.Body = buffer;
-
-        await next(context);
-
-        context.Response.Body = originalBody;
-        buffer.Position = 0;
-
-        if (context.Response.StatusCode != StatusCodes.Status200OK ||
-            !IsJson(context.Response.ContentType))
-        {
-            await buffer.CopyToAsync(originalBody);
-            return;
-        }
-
-        using var document = await JsonDocument.ParseAsync(buffer);
-        var response = new Dictionary<string, object?>(StringComparer.Ordinal);
-        foreach (var property in document.RootElement.EnumerateObject())
-            response[property.Name] = ConvertJsonValue(property.Value);
-
-        if (response.TryGetValue("access_token", out var accessValue) &&
-            accessValue is string accessToken &&
-            !string.IsNullOrWhiteSpace(accessToken))
-        {
-            AddLegacyTokenAliases(response, accessToken);
-            SetAccessCookie(context, accessToken);
-        }
-
-        var bytes = JsonSerializer.SerializeToUtf8Bytes(response);
-        context.Response.ContentLength = bytes.Length;
-        context.Response.ContentType = "application/json; charset=utf-8";
-        await originalBody.WriteAsync(bytes);
-    }
-
-    private static bool IsTokenRequest(HttpContext context) =>
-        HttpMethods.IsPost(context.Request.Method)
-        && context.Request.Path.Equals("/connect/token", StringComparison.OrdinalIgnoreCase);
-
-    private static bool IsJson(string? contentType) =>
-        contentType?.StartsWith("application/json", StringComparison.OrdinalIgnoreCase) == true;
-
-    private static object? ConvertJsonValue(JsonElement value) =>
-        value.ValueKind switch
-        {
-            JsonValueKind.String => value.GetString(),
-            JsonValueKind.Number when value.TryGetInt64(out var l) => l,
-            JsonValueKind.Number => value.GetDouble(),
-            JsonValueKind.True => true,
-            JsonValueKind.False => false,
-            JsonValueKind.Null => null,
-            _ => JsonSerializer.Deserialize<object>(value.GetRawText()),
-        };
-
-    private static void AddLegacyTokenAliases(Dictionary<string, object?> response, string accessToken)
-    {
-        response["Access_token"] = accessToken;
-        response["accessToken"] = accessToken;
-        response["AccessToken"] = accessToken;
-        response["token"] = accessToken;
-        response["Token"] = accessToken;
-        response["tokenType"] = "Bearer";
-        response["TokenType"] = "Bearer";
-
-        if (response.TryGetValue("expires_in", out var expiresIn))
-        {
-            response["expiresIn"] = expiresIn;
-            response["ExpiresIn"] = expiresIn;
-        }
-
-        if (response.TryGetValue("refresh_token", out var refreshToken))
-        {
-            response["Refresh_token"] = refreshToken;
-            response["refreshToken"] = refreshToken;
-            response["RefreshToken"] = refreshToken;
-        }
-
-        var signingKey = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
-        response["key"] = signingKey;
-        response["Key"] = signingKey;
-    }
-
-    private void SetAccessCookie(HttpContext context, string accessToken)
-    {
-        var cookie = new CookieOptions
-        {
-            HttpOnly = true,
-            Secure = string.Equals(domain.Scheme, "https", StringComparison.OrdinalIgnoreCase),
-            SameSite = SameSiteMode.None,
-            Expires = DateTimeOffset.UtcNow.AddHours(12),
-            IsEssential = true,
-        };
-        if (domain.Apex.Contains('.'))
-            cookie.Domain = "." + domain.Apex;
-        context.Response.Cookies.Append(AuthService.AccessCookieName, accessToken, cookie);
     }
 }
 

--- a/DorkNet.Server/Controllers/Admin/AdminController.cs
+++ b/DorkNet.Server/Controllers/Admin/AdminController.cs
@@ -1169,6 +1169,7 @@ public class AdminController(
         var client = RecRoomIdentityServerConfig.Clients[0];
         var certPath = signingKeys.CertificatePath;
         var fullCertPath = Path.GetFullPath(certPath);
+        var certificateExists = signingKeys.LoadedFromBase64 || System.IO.File.Exists(fullCertPath);
         var licenseConfigured =
             !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("DUENDE_IDENTITYSERVER_LICENSE_KEY"))
             || !string.IsNullOrWhiteSpace(config["IdentityServer:LicenseKey"]);
@@ -1194,8 +1195,10 @@ public class AdminController(
             },
             Signing = new
             {
+                signingKeys.CertificateSource,
+                signingKeys.LoadedFromBase64,
                 CertificatePath = fullCertPath,
-                CertificateExists = System.IO.File.Exists(fullCertPath),
+                CertificateExists = certificateExists,
                 signingKeys.Certificate.Thumbprint,
                 NotBeforeUtc = signingKeys.Certificate.NotBefore.ToUniversalTime(),
                 NotAfterUtc = signingKeys.Certificate.NotAfter.ToUniversalTime(),

--- a/DorkNet.Server/Controllers/Admin/AdminController.cs
+++ b/DorkNet.Server/Controllers/Admin/AdminController.cs
@@ -1213,13 +1213,6 @@ public class AdminController(
                 Store = "in-memory",
                 Warning = "Refresh tokens are process-local until an operational store is configured.",
             },
-            LegacyCompatibility = new
-            {
-                InjectsClientId = true,
-                InjectsDefaultScopes = true,
-                AddsLegacyTokenAliases = true,
-                AcceptsLegacyJwtSigningKey = true,
-            },
         });
     }
     /// <summary>GET <c>api/admin/v1/settings</c> — current server-wide

--- a/DorkNet.Server/Controllers/Admin/AdminController.cs
+++ b/DorkNet.Server/Controllers/Admin/AdminController.cs
@@ -40,7 +40,6 @@ public class AdminController(
     SignupCodeService signupCodes,
     IObjectStorage storage,
     DomainConfig domain,
-    IConfiguration config,
     IdentityServerSigningKeyProvider signingKeys,
     ILogger<AdminController> adminLogger) : ControllerBase
 {
@@ -1170,9 +1169,6 @@ public class AdminController(
         var certPath = signingKeys.CertificatePath;
         var fullCertPath = Path.GetFullPath(certPath);
         var certificateExists = signingKeys.LoadedFromBase64 || System.IO.File.Exists(fullCertPath);
-        var licenseConfigured =
-            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("DUENDE_IDENTITYSERVER_LICENSE_KEY"))
-            || !string.IsNullOrWhiteSpace(config["IdentityServer:LicenseKey"]);
 
         return Ok(new
         {
@@ -1203,10 +1199,6 @@ public class AdminController(
                 NotBeforeUtc = signingKeys.Certificate.NotBefore.ToUniversalTime(),
                 NotAfterUtc = signingKeys.Certificate.NotAfter.ToUniversalTime(),
                 Algorithm = SecurityAlgorithms.RsaSha256,
-            },
-            License = new
-            {
-                Configured = licenseConfigured,
             },
             PersistedGrants = new
             {

--- a/DorkNet.Server/Controllers/Admin/AdminController.cs
+++ b/DorkNet.Server/Controllers/Admin/AdminController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
 using DorkNet.Models.Notification;
 using DorkNet.Server.Auth;
 using DorkNet.Server.Data;
@@ -39,6 +40,8 @@ public class AdminController(
     SignupCodeService signupCodes,
     IObjectStorage storage,
     DomainConfig domain,
+    IConfiguration config,
+    IdentityServerSigningKeyProvider signingKeys,
     ILogger<AdminController> adminLogger) : ControllerBase
 {
     private long CurrentAdminId => this.RequireCurrentPlayerId();
@@ -1159,6 +1162,63 @@ public class AdminController(
 
     // ── Server settings (runtime toggles) ────────────────────────────────
 
+    [HttpGet("identityserver")]
+    public ActionResult GetIdentityServerSettings()
+    {
+        var issuer = domain.AuthIssuer.TrimEnd('/');
+        var client = RecRoomIdentityServerConfig.Clients[0];
+        var certPath = signingKeys.CertificatePath;
+        var fullCertPath = Path.GetFullPath(certPath);
+        var licenseConfigured =
+            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("DUENDE_IDENTITYSERVER_LICENSE_KEY"))
+            || !string.IsNullOrWhiteSpace(config["IdentityServer:LicenseKey"]);
+
+        return Ok(new
+        {
+            Issuer = issuer,
+            DiscoveryUrl = $"{issuer}/.well-known/openid-configuration",
+            TokenEndpoint = $"{issuer}/connect/token",
+            UserInfoEndpoint = $"{issuer}/connect/userinfo",
+            Client = new
+            {
+                client.ClientId,
+                client.ClientName,
+                AllowedGrantTypes = client.AllowedGrantTypes.ToArray(),
+                AllowedScopes = client.AllowedScopes.ToArray(),
+                client.AllowOfflineAccess,
+                client.AccessTokenLifetime,
+                client.AbsoluteRefreshTokenLifetime,
+                client.SlidingRefreshTokenLifetime,
+                RefreshTokenUsage = client.RefreshTokenUsage.ToString(),
+                RefreshTokenExpiration = client.RefreshTokenExpiration.ToString(),
+            },
+            Signing = new
+            {
+                CertificatePath = fullCertPath,
+                CertificateExists = System.IO.File.Exists(fullCertPath),
+                signingKeys.Certificate.Thumbprint,
+                NotBeforeUtc = signingKeys.Certificate.NotBefore.ToUniversalTime(),
+                NotAfterUtc = signingKeys.Certificate.NotAfter.ToUniversalTime(),
+                Algorithm = SecurityAlgorithms.RsaSha256,
+            },
+            License = new
+            {
+                Configured = licenseConfigured,
+            },
+            PersistedGrants = new
+            {
+                Store = "in-memory",
+                Warning = "Refresh tokens are process-local until an operational store is configured.",
+            },
+            LegacyCompatibility = new
+            {
+                InjectsClientId = true,
+                InjectsDefaultScopes = true,
+                AddsLegacyTokenAliases = true,
+                AcceptsLegacyJwtSigningKey = true,
+            },
+        });
+    }
     /// <summary>GET <c>api/admin/v1/settings</c> — current server-wide
     /// toggle state. Single row, single round trip.</summary>
     [HttpGet("settings")]

--- a/DorkNet.Server/Controllers/Auth/AuthController.cs
+++ b/DorkNet.Server/Controllers/Auth/AuthController.cs
@@ -6,7 +6,7 @@ using DorkNet.Server.Services;
 namespace DorkNet.Server.Controllers.Auth;
 
 /// <summary>
-/// auth.rec.net game-specific auth helpers. OAuth/OIDC endpoints are owned by Duende IdentityServer.
+/// auth.rec.net game-specific auth helpers. OAuth/OIDC endpoints are owned by IdentityServer.
 /// </summary>
 [ApiController]
 public class AuthController(

--- a/DorkNet.Server/Controllers/Auth/AuthController.cs
+++ b/DorkNet.Server/Controllers/Auth/AuthController.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using DorkNet.Models.Auth;
 using DorkNet.Server.Data.Entities;
 using DorkNet.Server.Services;
@@ -7,242 +6,26 @@ using DorkNet.Server.Services;
 namespace DorkNet.Server.Controllers.Auth;
 
 /// <summary>
-/// auth.rec.net — OAuth-style token endpoint used by 2019+ builds alongside PlatformLogin.
+/// auth.rec.net game-specific auth helpers. OAuth/OIDC endpoints are owned by Duende IdentityServer.
 /// </summary>
 [ApiController]
 public class AuthController(
     PlayerService playerService,
-    AuthService authService,
-    LevelService level,
-    OrphanAccountTracker orphans,
-    ServerSettingsService settings,
-    DorkNet.Server.Data.DorkNetDbContext db,
-    DomainConfig domain,
-    ILogger<AuthController> logger) : ControllerBase
+    AuthService authService) : ControllerBase
 {
-    /// <summary>Award the per-day first-login XP if the calling
-    /// player hasn't been seen yet today (UTC).</summary>
-    private async Task TryAwardLoginXpAsync(long playerId)
-    {
-        var lastSeen = await db.Players
-            .Where(p => p.Id == playerId)
-            .Select(p => p.LastSeenAt)
-            .FirstOrDefaultAsync();
-        if (lastSeen.Date < DateTime.UtcNow.Date)
-            await level.AwardXpAsync(playerId, LevelService.FirstLoginXp, "first_login_today");
-    }
-    // OAuth token endpoint. The 2020 client uses three grant types here:
-    // - grant_type=cached_login → user clicked a remembered account on the
-    //   account-selection screen. Body includes `account_id` (and platform
-    //   creds). MUST issue a token for THAT specific account; otherwise the
-    //   client receives a JWT for a different account and prompts the user
-    //   to create a new one (because the JWT identity doesn't match what
-    //   they picked).
-    // - grant_type=refresh_token → re-issue access token from the existing
-    //   refresh JWT.
-    // - grant_type=password → first-time sign-in, resolve via deviceId
-    //   (preferred) or fall back to a stable synthetic id derived from
-    //   username so legacy callers don't share accounts.
-    [HttpPost("/connect/token")]
-    [Consumes("application/x-www-form-urlencoded")]
-    public async Task<IActionResult> Token(
-        [FromForm] string? grant_type,
-        [FromForm] string? username,
-        [FromForm] string? password,
-        [FromForm] string? refresh_token,
-        [FromForm] string? deviceId,
-        [FromForm(Name = "device_id")] string? device_id_snake,
-        [FromForm] int platform = 0,
-        [FromForm] string? platformId = null,
-        [FromForm(Name = "platform_id")] string? platform_id_snake = null,
-        [FromForm] long? account_id = null)
-    {
-        // The client mixes camelCase and snake_case parameter naming
-        // depending on grant type — accept both and merge.
-        var effDeviceId = !string.IsNullOrWhiteSpace(deviceId) ? deviceId : device_id_snake;
-        var effPlatformId = !string.IsNullOrWhiteSpace(platformId) ? platformId : platform_id_snake;
-
-        if (string.Equals(grant_type, "cached_login", StringComparison.OrdinalIgnoreCase))
-        {
-            if (account_id is not long pickedId)
-                return BadRequest(new { error = "invalid_request", error_description = "missing account_id" });
-            var picked = await playerService.GetByIdAsync(pickedId);
-            if (picked is null)
-                return Unauthorized(new { error = "invalid_grant", error_description = "unknown account_id" });
-
-            // Orphan cleanup: if the watch just created a brand-new
-            // account on account/create as part of its boot probe, but
-            // the user actually picked a different cached account here,
-            // the just-created row is unused. Delete it so the DB
-            // doesn't accumulate one orphan per game launch. When the
-            // user is genuinely creating a new account, the picked id
-            // matches the just-created id and we leave it.
-            var pendingId = orphans.PeekPending(effDeviceId, effPlatformId);
-            if (pendingId is long orphanId && orphanId != pickedId)
-            {
-                await playerService.DeleteOrphanAsync(orphanId);
-                logger.LogInformation(
-                    "[orphan-cleanup] cached_login picked {PickedId}; deleted just-created {OrphanId}",
-                    pickedId, orphanId);
-            }
-            orphans.Clear(effDeviceId, effPlatformId);
-
-            await TryAwardLoginXpAsync(picked.Id);
-            await playerService.TagPlatformAsync(picked.Id, platform, effPlatformId);
-            var (acc1, refr1) = authService.GenerateTokenPair(picked.Id);
-            return Ok(new
-            {
-                access_token = acc1,
-                token_type = "Bearer",
-                expires_in = 43200,
-                refresh_token = refr1,
-                scope = "openid profile",
-            });
-        }
-
-        if (string.Equals(grant_type, "refresh_token", StringComparison.OrdinalIgnoreCase))
-        {
-            if (string.IsNullOrWhiteSpace(refresh_token))
-                return BadRequest(new { error = "invalid_request" });
-            var resolved = authService.ValidateToken(refresh_token);
-            if (resolved is not long refreshedId)
-                return Unauthorized(new { error = "invalid_grant" });
-            var existing = await playerService.GetByIdAsync(refreshedId);
-            if (existing is null)
-                return Unauthorized(new { error = "invalid_grant" });
-            var (acc, refr) = authService.GenerateTokenPair(existing.Id);
-            return Ok(new
-            {
-                access_token = acc,
-                token_type = "Bearer",
-                expires_in = 43200,
-                refresh_token = refr,
-                scope = "openid profile",
-            });
-        }
-
-        // password grant: two paths.
-        //   • Username + password supplied: real password verify against
-        //     PlayerEntity.PasswordHash. Wrong password → 401.
-        //   • No password: legacy device-id synth path for the 2020
-        //     client's first-launch flow where the player hasn't set a
-        //     password yet (HasPassword returns false in the watch UI
-        //     and prompts them to create one). Resolves the existing
-        //     account (or creates a fresh one) by deviceId.
-        if (!string.IsNullOrEmpty(password) && !string.IsNullOrEmpty(username))
-        {
-            var byName = await playerService.GetByUsernameAsync(username);
-            if (byName is null || byName.PasswordHash is null)
-                return Unauthorized(new
-                {
-                    error = "invalid_grant",
-                    error_description = "unknown_user_or_no_password",
-                });
-            if (!BCrypt.Net.BCrypt.Verify(password, byName.PasswordHash))
-                return Unauthorized(new
-                {
-                    error = "invalid_grant",
-                    error_description = "password_mismatch",
-                });
-            // Tag the platform so the next boot's cached-login lookup
-            // finds this account — without this the watch's "remembered
-            // accounts" prompt would stay empty after a manual sign-in.
-            await playerService.TagPlatformAsync(byName.Id, platform, effPlatformId);
-            await TryAwardLoginXpAsync(byName.Id);
-            var pair = authService.GenerateTokenPair(byName.Id);
-            return Ok(new
-            {
-                access_token = pair.AccessToken,
-                token_type = "Bearer",
-                expires_in = 43200,
-                refresh_token = pair.RefreshToken,
-                scope = "openid profile",
-            });
-        }
-
-        // Device-id fallback path. Prefer the real deviceId; fall back
-        // to a stable legacy synthesis from username so older callers
-        // don't accidentally share an account.
-        var effectiveDeviceId = !string.IsNullOrWhiteSpace(effDeviceId)
-            ? effDeviceId
-            : $"legacy-{(username ?? "anonymous").ToLowerInvariant()}";
-
-        // Honour the admin "signups disabled" toggle. If the device
-        // hasn't logged in before, GetOrCreateByDeviceAsync would mint
-        // a fresh account here — same outcome as hitting
-        // /account/create directly, which the toggle blocks. Refuse
-        // BEFORE creation so the flag isn't bypassable.
-        if (await settings.AreSignupsDisabledAsync())
-        {
-            var existing = await playerService.GetByDeviceAsync(effectiveDeviceId);
-            if (existing is null)
-            {
-                logger.LogInformation(
-                    "[auth] /connect/token device fallback refused — signups disabled (device={Device})",
-                    effectiveDeviceId);
-                return Unauthorized(new
-                {
-                    error = "signups_disabled",
-                    error_description = "Account creation is currently disabled by the server admin.",
-                });
-            }
-        }
-
-        var player = await playerService.GetOrCreateByDeviceAsync(
-            deviceId: effectiveDeviceId,
-            platform: platform,
-            platformId: effPlatformId,
-            displayName: username);
-        await TryAwardLoginXpAsync(player.Id);
-        var (access, refresh) = authService.GenerateTokenPair(player.Id);
-
-        return Ok(new
-        {
-            access_token = access,
-            token_type = "Bearer",
-            expires_in = 43200,
-            refresh_token = refresh,
-            scope = "openid profile",
-        });
-    }
-
-    [HttpGet("/connect/userinfo")]
-    public async Task<IActionResult> UserInfo()
-    {
-        var auth = Request.Headers.Authorization.ToString();
-        if (!auth.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-            return Unauthorized();
-        var token = auth["Bearer ".Length..].Trim();
-        var id = authService.ValidateToken(token);
-        if (id is not long playerId) return Unauthorized();
-        var player = await playerService.GetByIdAsync(playerId);
-        if (player is null) return Unauthorized();
-        return Ok(new { sub = player.Id.ToString(), name = player.Username });
-    }
-
-    // Discovery document — issuer + endpoints derived from
-    // DomainConfig so a single DORKNET_DOMAIN env var keeps the
-    // OpenID document pointed at the live deployment.
-    [HttpGet("/.well-known/openid-configuration")]
-    public IActionResult OpenIdConfig()
-    {
-        var base_ = $"https://{domain.Sub("auth")}";
-        return Ok(new
-        {
-            issuer = base_,
-            token_endpoint = $"{base_}/connect/token",
-            userinfo_endpoint = $"{base_}/connect/userinfo",
-        });
-    }
+    // 2020.12 added an EAC challenge step in the login flow. The client GETs
+    // a challenge string and passes it to EACManager.GenerateChallengeResponse,
+    // which calls System.Convert.FromBase64CharPtr on the string. So the
+    // returned challenge MUST be valid base64 — sending arbitrary text throws
+    // FormatException client-side and kicks the login.
+    [HttpGet("/eac/challenge")]
+    [HttpPost("/eac/challenge")]
+    public IActionResult EacChallenge()
+        => Content("\"AAAAAAAAAAAAAAAAAAAAAAAA\"", "application/json");
 
     // Cached-logins lookup — boot-sequence call from ScreenAccountSelectionManager.
     // URL: GET auth.rec.net/cachedlogin/forplatformid/{platform}/{platformId}
     // Returns List<Login.CachedLogin>. Empty array = no remembered accounts.
-    //
-    // Real lookup: any account whose last platformlogin matched
-    // (platform, platformId) shows up here, sorted most-recent-first. On a
-    // single-Steam-emu setup that's one row; on a multi-account dev box
-    // it's the full list the user has cycled through.
     [HttpGet("/cachedlogin/forplatformid/{platform:int}/{platformId}")]
     public async Task<IActionResult> CachedLoginsForPlatform(int platform, string platformId)
     {
@@ -252,10 +35,8 @@ public class AuthController(
 
     /// <summary>POST <c>cachedlogin/forplatformids</c> — bulk variant
     /// the watch uses when hydrating multiple platform-id mappings
-    /// at once (e.g. populating a friend list from Steam ids). Body
-    /// is form-urlencoded <c>platform=&amp;platformIds=a,b,c</c> or
-    /// JSON with the same shape. Returns the flattened
-    /// <c>List&lt;CachedLogin&gt;</c> across every matched id.</summary>
+    /// at once. Body is form-urlencoded <c>platform=&amp;platformIds=a,b,c</c>
+    /// or JSON with the same shape.</summary>
     [HttpPost("/cachedlogin/forplatformids")]
     [HttpGet("/cachedlogin/forplatformids")]
     public async Task<IActionResult> CachedLoginsForPlatformIds()
@@ -273,6 +54,7 @@ public class AuthController(
             }
         }
         catch { /* not form */ }
+
         if (string.IsNullOrWhiteSpace(rawIds))
         {
             int.TryParse(Request.Query["platform"], out platform);
@@ -295,13 +77,50 @@ public class AuthController(
         return Ok(results);
     }
 
-    private static CachedLogin ToCachedLogin(PlayerEntity p, int platform, string platformId) => new()
+    [HttpGet("/cachedlogin/current")]
+    public async Task<IActionResult> CurrentCachedLogin()
+    {
+        var token = GetBearerToken();
+        if (token is null) return Unauthorized();
+        var id = authService.ValidateToken(token);
+        if (id is not long playerId) return Unauthorized();
+        var player = await playerService.GetByIdAsync(playerId);
+        if (player is null) return Unauthorized();
+        return Ok(ToCachedLogin(player, player.LastPlatform, player.LastPlatformId));
+    }
+
+    [HttpPost("/cachedlogin/migrate")]
+    public async Task<IActionResult> MigrateCachedLogin(
+        [FromForm] int platform = 0,
+        [FromForm] string? platformId = null)
+    {
+        var token = GetBearerToken();
+        if (token is null) return Unauthorized();
+        var id = authService.ValidateToken(token);
+        if (id is not long playerId) return Unauthorized();
+        await playerService.TagPlatformAsync(playerId, platform, platformId);
+        var player = await playerService.GetByIdAsync(playerId);
+        return player is null
+            ? Unauthorized()
+            : Ok(ToCachedLogin(player, platform, platformId ?? string.Empty));
+    }
+
+    private string? GetBearerToken()
+    {
+        var auth = Request.Headers.Authorization.ToString();
+        if (auth.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            return auth["Bearer ".Length..].Trim();
+        return Request.Cookies.TryGetValue(AuthService.AccessCookieName, out var cookieToken)
+            ? cookieToken
+            : null;
+    }
+
+    private static CachedLogin ToCachedLogin(PlayerEntity p, int platform, string? platformId) => new()
     {
         Platform = platform,
-        PlatformId = platformId,
+        PlatformId = platformId ?? string.Empty,
         AccountId = (int)p.Id,
         LastLoginTime = p.LastSeenAt,
         RequirePassword = false,
     };
-
 }

--- a/DorkNet.Server/DorkNet.Server.csproj
+++ b/DorkNet.Server/DorkNet.Server.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Duende.IdentityServer" Version="7.4.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.15" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">

--- a/DorkNet.Server/DorkNet.Server.csproj
+++ b/DorkNet.Server/DorkNet.Server.csproj
@@ -1,21 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Duende.IdentityServer" Version="7.4.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.15" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">
+    <PackageReference Include="Open.IdentityServer" Version="1.0.0" />
+    <PackageReference Include="MessagePack" Version="3.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <!-- RenderedCompactJsonFormatter for stdout JSON logs in production
          (Coolify-friendly). The host pipeline reads stdout line-by-line,
          and structured JSON lets a future Loki/Datadog ingest parse fields
@@ -26,8 +27,8 @@
          scale: SignalR group fanout, OrphanAccountTracker (sticky-session
          account-creation flow), and PlayerPresenceService heartbeats all
          need shared state across replicas. -->
-    <PackageReference Include="StackExchange.Redis" Version="2.8.16" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="9.0.4" />
+    <PackageReference Include="StackExchange.Redis" Version="2.13.17" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.9" />
     <!-- S3-compatible object storage. Production target: Garage in
          Coolify (one-click). Dev fallback: local MinIO for parity
          testing. The SDK speaks plain S3, so swapping endpoints
@@ -39,7 +40,7 @@
          cost+salt in the output string so we only need one column. -->
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <!-- Server-side crop/resize for img.* CDN transforms (?cropSquare=1&width=N
          on profile thumbnails). The 2020 client treats this as part of the
          image CDN contract — it uploads a full-frame capture and expects the

--- a/DorkNet.Server/Program.cs
+++ b/DorkNet.Server/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
+using DorkNet.Server.Auth;
 using DorkNet.Server.Data;
 using DorkNet.Server.Services;
 using Serilog;
@@ -105,7 +106,8 @@ var domainPort =
 var singleOriginBaseUrl =
     builder.Configuration["Domain:SingleOriginBaseUrl"]
     ?? Environment.GetEnvironmentVariable("DORKNET_SINGLE_ORIGIN_BASE_URL");
-builder.Services.AddSingleton(new DomainConfig(apex, domainScheme, domainPort, singleOriginBaseUrl));
+var domainConfig = new DomainConfig(apex, domainScheme, domainPort, singleOriginBaseUrl);
+builder.Services.AddSingleton(domainConfig);
 builder.Services.Configure<Microsoft.AspNetCore.HostFiltering.HostFilteringOptions>(opt =>
 {
     opt.AllowedHosts = new[] { apex, $"*.{apex}", "localhost", "127.0.0.1" };
@@ -214,12 +216,9 @@ static string NormalizeRedisConn(string raw)
 // kept for backward compat with older Coolify configs (will warn at
 // startup, can be removed once everyone has migrated). AuthService
 // has the matching fallback so signing + validation use the same key.
-var jwtSecret = Environment.GetEnvironmentVariable("DORKNET_JWT_SECRET")
-    ?? Environment.GetEnvironmentVariable("RECNET_JWT_SECRET")
-    ?? builder.Configuration["Jwt:Secret"]
-    ?? throw new InvalidOperationException(
-        "JWT secret not configured. Set the DORKNET_JWT_SECRET env var or " +
-        "add `Jwt:Secret` to appsettings.Local.json.");
+var signingKeyProvider = new IdentityServerSigningKeyProvider(builder.Configuration);
+builder.Services.AddSingleton(signingKeyProvider);
+builder.Services.AddRecRoomIdentityServer(builder.Configuration, domainConfig, signingKeyProvider);
 
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(opt =>
@@ -227,9 +226,9 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
         opt.TokenValidationParameters = new TokenValidationParameters
         {
             ValidateIssuerSigningKey = true,
-            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSecret)),
+            IssuerSigningKeys = signingKeyProvider.ValidationKeys,
             ValidateIssuer = true,
-            ValidIssuer = "https://api.rec.net/",
+            ValidIssuers = new[] { domainConfig.AuthIssuer, AuthService.LegacyIssuer },
             ValidateAudience = false,
             ClockSkew = TimeSpan.Zero,
         };
@@ -251,6 +250,12 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 var path = ctx.HttpContext.Request.Path;
                 if (!string.IsNullOrEmpty(accessToken) && path.StartsWithSegments("/hub"))
                     ctx.Token = accessToken;
+                if (string.IsNullOrEmpty(ctx.Token) &&
+                    ctx.Request.Cookies.TryGetValue(AuthService.AccessCookieName, out var cookieToken) &&
+                    !string.IsNullOrWhiteSpace(cookieToken))
+                {
+                    ctx.Token = cookieToken;
+                }
                 return Task.CompletedTask;
             },
         };
@@ -1155,6 +1160,10 @@ app.Use(async (ctx, next) =>
 // gets cut off at the earliest point possible — no JWT round-trip,
 // no DB hit beyond the (small) IpBans lookup.
 app.UseMiddleware<DorkNet.Server.Auth.IpBanCheckMiddleware>();
+
+app.UseMiddleware<IdentityServerTokenResponseMiddleware>();
+app.UseMiddleware<IdentityServerLegacyTokenRequestMiddleware>();
+app.UseIdentityServer();
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/DorkNet.Server/Program.cs
+++ b/DorkNet.Server/Program.cs
@@ -1161,8 +1161,7 @@ app.Use(async (ctx, next) =>
 // no DB hit beyond the (small) IpBans lookup.
 app.UseMiddleware<DorkNet.Server.Auth.IpBanCheckMiddleware>();
 
-app.UseMiddleware<IdentityServerTokenResponseMiddleware>();
-app.UseMiddleware<IdentityServerLegacyTokenRequestMiddleware>();
+app.UseMiddleware<IdentityServerGameTokenRequestMiddleware>();
 app.UseIdentityServer();
 
 app.UseAuthentication();

--- a/DorkNet.Server/Services/AuthService.cs
+++ b/DorkNet.Server/Services/AuthService.cs
@@ -3,12 +3,16 @@ using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using DorkNet.Server.Auth;
 using DorkNet.Server.Data;
 
 namespace DorkNet.Server.Services;
 
-public class AuthService(IConfiguration config, DorkNetDbContext db)
+public class AuthService(IConfiguration config, DorkNetDbContext db, DomainConfig domain, IdentityServerSigningKeyProvider signingKeyProvider)
 {
+    public const string AccessCookieName = "dorknet_access_token";
+    public const string LegacyIssuer = "https://api.rec.net/";
+
     // Resolution order MUST match Program.cs's JwtBearer validator setup —
     // env var first, config key second — otherwise tokens are signed with
     // one secret and validated against another and every authenticated
@@ -38,38 +42,17 @@ public class AuthService(IConfiguration config, DorkNetDbContext db)
     private string CreateJwt(long playerId, TimeSpan lifetime, string tokenType)
     {
         var handler = new JwtSecurityTokenHandler();
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(SecretKey));
-
-        // Look up dev/admin flags so the JWT carries a "developer" role
-        // claim for accounts that should see the in-game debug button.
-        // The watch's Login.SetAccessToken parses the access_token's
-        // <c>role</c> claim — either a single string or a list — and
-        // calls <c>HasRole("developer", token)</c>; that result drives
-        // <c>Accounts.SetLocalAccountIsDev</c> and ultimately
-        // <c>SessionManager.IsDeveloper</c>, which the watch UI checks
-        // when deciding whether to show the dev console toggle.
-        var isDev = db.Players
-            .Where(p => p.Id == playerId)
-            .Select(p => (bool?)(p.IsDeveloper || p.IsAdmin))
-            .FirstOrDefault() ?? false;
-
-        var claims = new List<Claim>
-        {
-            new(ClaimTypes.NameIdentifier, playerId.ToString()),
-            new(ClaimTypes.Role, "gameClient"),
-            new("token_type", tokenType),
-        };
-        // Multiple Role claims become a JSON array on the wire — the
-        // watch's HasRole helper handles both string and List<string>
-        // forms.
-        if (isDev) claims.Add(new Claim(ClaimTypes.Role, "developer"));
+        var claims = RecRoomIdentityClaims.CreateAsync(db, playerId)
+            .GetAwaiter()
+            .GetResult();
+        claims.Add(new Claim("token_type", tokenType));
 
         var descriptor = new SecurityTokenDescriptor
         {
             Subject = new ClaimsIdentity(claims),
             Expires = DateTime.UtcNow.Add(lifetime),
-            Issuer = "https://api.rec.net/",
-            SigningCredentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256),
+            Issuer = domain.AuthIssuer,
+            SigningCredentials = new SigningCredentials(signingKeyProvider.SigningKey, SecurityAlgorithms.RsaSha256),
         };
 
         return handler.WriteToken(handler.CreateJwtSecurityToken(descriptor));
@@ -80,19 +63,22 @@ public class AuthService(IConfiguration config, DorkNetDbContext db)
         try
         {
             var handler = new JwtSecurityTokenHandler();
-            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(SecretKey));
-
             var principal = handler.ValidateToken(token, new TokenValidationParameters
             {
                 ValidateIssuerSigningKey = true,
-                IssuerSigningKey = key,
+                IssuerSigningKeys = signingKeyProvider.ValidationKeys,
                 ValidateIssuer = true,
-                ValidIssuer = "https://api.rec.net/",
+                ValidIssuers = new[] { domain.AuthIssuer, LegacyIssuer },
                 ValidateAudience = false,
                 ClockSkew = TimeSpan.Zero,
             }, out _);
 
-            var idClaim = principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var idClaim = principal.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                ?? principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+                ?? principal.FindFirst("sub")?.Value
+                ?? principal.FindFirst("accountId")?.Value
+                ?? principal.FindFirst("account_id")?.Value
+                ?? principal.FindFirst("accountid")?.Value;
             return idClaim is not null ? long.Parse(idClaim) : null;
         }
         catch

--- a/DorkNet.Server/Services/DomainConfig.cs
+++ b/DorkNet.Server/Services/DomainConfig.cs
@@ -27,6 +27,7 @@ public sealed class DomainConfig
     }
 
     public string Sub(string prefix) => $"{prefix}.{Apex}";
+    public string AuthIssuer => SubUrl("auth");
     public string Url(string host) => Port is null ? $"{Scheme}://{host}" : $"{Scheme}://{host}:{Port}";
     public string SubUrl(string prefix) => Url(Sub(prefix));
     public static bool MatchesSubdomain(string host, string prefix)

--- a/DorkNet.Server/admin-ui/src/pages/IdentityServer.tsx
+++ b/DorkNet.Server/admin-ui/src/pages/IdentityServer.tsx
@@ -20,6 +20,8 @@ interface IdentityServerSettings {
     refreshTokenExpiration: string;
   };
   signing: {
+    certificateSource: string;
+    loadedFromBase64: boolean;
     certificatePath: string;
     certificateExists: boolean;
     thumbprint: string;
@@ -139,7 +141,10 @@ export function IdentityServer() {
             <div className="card !p-5">
               <h2 className="text-sm font-semibold text-ink-50">Signing certificate</h2>
               <div className="mt-4 space-y-3">
-                <Detail label="Path" value={settings.signing.certificatePath} mono />
+                <Detail label="Source" value={settings.signing.certificateSource} mono />
+                {!settings.signing.loadedFromBase64 && (
+                  <Detail label="Path" value={settings.signing.certificatePath} mono />
+                )}
                 <Detail label="Thumbprint" value={settings.signing.thumbprint} mono />
                 <Detail label="Algorithm" value={settings.signing.algorithm} mono />
                 <Detail label="Valid from" value={formatDate(settings.signing.notBeforeUtc)} />

--- a/DorkNet.Server/admin-ui/src/pages/IdentityServer.tsx
+++ b/DorkNet.Server/admin-ui/src/pages/IdentityServer.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useState } from 'react';
+import { get } from '../lib/api';
+import { RefreshCw } from '../components/Icons';
+
+interface IdentityServerSettings {
+  issuer: string;
+  discoveryUrl: string;
+  tokenEndpoint: string;
+  userInfoEndpoint: string;
+  client: {
+    clientId: string;
+    clientName: string;
+    allowedGrantTypes: string[];
+    allowedScopes: string[];
+    allowOfflineAccess: boolean;
+    accessTokenLifetime: number;
+    absoluteRefreshTokenLifetime: number;
+    slidingRefreshTokenLifetime: number;
+    refreshTokenUsage: string;
+    refreshTokenExpiration: string;
+  };
+  signing: {
+    certificatePath: string;
+    certificateExists: boolean;
+    thumbprint: string;
+    notBeforeUtc: string;
+    notAfterUtc: string;
+    algorithm: string;
+  };
+  license: {
+    configured: boolean;
+  };
+  persistedGrants: {
+    store: string;
+    warning: string;
+  };
+  legacyCompatibility: {
+    injectsClientId: boolean;
+    injectsDefaultScopes: boolean;
+    addsLegacyTokenAliases: boolean;
+    acceptsLegacyJwtSigningKey: boolean;
+  };
+}
+
+export function IdentityServer() {
+  const [settings, setSettings] = useState<IdentityServerSettings | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const load = async () => {
+    setBusy(true);
+    try {
+      const data = await get<IdentityServerSettings>('/identityserver');
+      setSettings(data);
+      setErr(null);
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  useEffect(() => { void load(); }, []);
+
+  return (
+    <div>
+      <div className="mb-3 flex justify-end">
+        <button onClick={load} className="btn-secondary text-xs" disabled={busy}>
+          <RefreshCw className={busy ? 'animate-spin' : ''} />
+          Refresh
+        </button>
+      </div>
+
+      {err && (
+        <div className="card border-danger/30 bg-danger/5 px-4 py-3 text-sm text-danger mb-4">{err}</div>
+      )}
+
+      {!settings && !err && (
+        <div className="card !p-6 text-center text-xs text-ink-400">Loading...</div>
+      )}
+
+      {settings && (
+        <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_360px]">
+          <div className="space-y-5">
+            <div className="card !p-5">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                  <h2 className="text-sm font-semibold text-ink-50">IdentityServer</h2>
+                  <p className="mt-1 break-all font-mono text-xs text-ink-300">{settings.issuer}</p>
+                </div>
+                <div className="flex flex-wrap gap-2 text-xs">
+                  <StatusBadge ok={settings.signing.certificateExists} on="Signing key" off="Missing key" />
+                  <StatusBadge ok={settings.license.configured} on="License set" off="No license key" />
+                </div>
+              </div>
+
+              <div className="mt-5 grid gap-3 md:grid-cols-3">
+                <Endpoint label="Discovery" value={settings.discoveryUrl} />
+                <Endpoint label="Token" value={settings.tokenEndpoint} />
+                <Endpoint label="UserInfo" value={settings.userInfoEndpoint} />
+              </div>
+            </div>
+
+            <div className="card !p-5">
+              <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-sm font-semibold text-ink-50">Client</h2>
+                  <p className="mt-1 font-mono text-xs text-ink-400">{settings.client.clientId}</p>
+                </div>
+                <span className={settings.client.allowOfflineAccess ? 'badge-online' : 'badge-neutral'}>
+                  Offline access {settings.client.allowOfflineAccess ? 'on' : 'off'}
+                </span>
+              </div>
+
+              <div className="grid gap-4 lg:grid-cols-2">
+                <ChipList title="Grant types" values={settings.client.allowedGrantTypes} />
+                <ChipList title="Scopes" values={settings.client.allowedScopes} />
+              </div>
+
+              <div className="mt-5 grid gap-3 sm:grid-cols-3">
+                <Metric label="Access token" value={duration(settings.client.accessTokenLifetime)} />
+                <Metric label="Refresh token" value={duration(settings.client.absoluteRefreshTokenLifetime)} />
+                <Metric label="Refresh mode" value={`${settings.client.refreshTokenUsage} / ${settings.client.refreshTokenExpiration}`} />
+              </div>
+            </div>
+
+            <div className="card !p-5">
+              <h2 className="text-sm font-semibold text-ink-50">Legacy compatibility</h2>
+              <div className="mt-4 grid gap-3 md:grid-cols-2">
+                <Compatibility label="Inject client_id for old clients" ok={settings.legacyCompatibility.injectsClientId} />
+                <Compatibility label="Merge default scopes" ok={settings.legacyCompatibility.injectsDefaultScopes} />
+                <Compatibility label="Add legacy token aliases" ok={settings.legacyCompatibility.addsLegacyTokenAliases} />
+                <Compatibility label="Accept legacy JWT signing key" ok={settings.legacyCompatibility.acceptsLegacyJwtSigningKey} />
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-5">
+            <div className="card !p-5">
+              <h2 className="text-sm font-semibold text-ink-50">Signing certificate</h2>
+              <div className="mt-4 space-y-3">
+                <Detail label="Path" value={settings.signing.certificatePath} mono />
+                <Detail label="Thumbprint" value={settings.signing.thumbprint} mono />
+                <Detail label="Algorithm" value={settings.signing.algorithm} mono />
+                <Detail label="Valid from" value={formatDate(settings.signing.notBeforeUtc)} />
+                <Detail label="Valid until" value={formatDate(settings.signing.notAfterUtc)} />
+              </div>
+            </div>
+
+            <div className="card !p-5">
+              <h2 className="text-sm font-semibold text-ink-50">Operational store</h2>
+              <div className="mt-3 flex items-center justify-between gap-3">
+                <span className="text-xs text-ink-400">Persisted grants</span>
+                <span className="badge-junior">{settings.persistedGrants.store}</span>
+              </div>
+              <p className="mt-4 text-xs leading-5 text-ink-400">{settings.persistedGrants.warning}</p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Endpoint({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-ink-800 bg-ink-950/40 p-3">
+      <div className="label">{label}</div>
+      <div className="mt-2 break-all font-mono text-xs text-ink-100">{value}</div>
+    </div>
+  );
+}
+
+function ChipList({ title, values }: { title: string; values: string[] }) {
+  return (
+    <div className="rounded-lg border border-ink-800 bg-ink-950/30 p-4">
+      <h3 className="text-xs font-semibold uppercase text-ink-400">{title}</h3>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {values.map((value) => (
+          <span key={value} className="badge-neutral font-mono normal-case tracking-normal">{value}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-ink-800 bg-ink-950/30 p-3">
+      <div className="text-[11px] uppercase text-ink-500">{label}</div>
+      <div className="mt-1 text-sm font-semibold text-ink-50">{value}</div>
+    </div>
+  );
+}
+
+function Compatibility({ label, ok }: { label: string; ok: boolean }) {
+  return (
+    <div className="flex min-h-10 items-center justify-between gap-3 rounded-md border border-ink-800 bg-ink-950/30 px-3 py-2">
+      <span className="text-xs text-ink-100">{label}</span>
+      <StatusBadge ok={ok} on="On" off="Off" />
+    </div>
+  );
+}
+
+function Detail({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div>
+      <div className="label">{label}</div>
+      <div className={(mono ? 'font-mono ' : '') + 'mt-1 break-all text-xs text-ink-100'}>{value}</div>
+    </div>
+  );
+}
+
+function StatusBadge({ ok, on, off }: { ok: boolean; on: string; off: string }) {
+  return <span className={ok ? 'badge-online' : 'badge-junior'}>{ok ? on : off}</span>;
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+function duration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return '0s';
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m`;
+  return `${seconds}s`;
+}

--- a/DorkNet.Server/admin-ui/src/pages/IdentityServer.tsx
+++ b/DorkNet.Server/admin-ui/src/pages/IdentityServer.tsx
@@ -29,9 +29,6 @@ interface IdentityServerSettings {
     notAfterUtc: string;
     algorithm: string;
   };
-  license: {
-    configured: boolean;
-  };
   persistedGrants: {
     store: string;
     warning: string;
@@ -86,7 +83,6 @@ export function IdentityServer() {
                 </div>
                 <div className="flex flex-wrap gap-2 text-xs">
                   <StatusBadge ok={settings.signing.certificateExists} on="Signing key" off="Missing key" />
-                  <StatusBadge ok={settings.license.configured} on="License set" off="No license key" />
                 </div>
               </div>
 

--- a/DorkNet.Server/admin-ui/src/pages/IdentityServer.tsx
+++ b/DorkNet.Server/admin-ui/src/pages/IdentityServer.tsx
@@ -36,12 +36,6 @@ interface IdentityServerSettings {
     store: string;
     warning: string;
   };
-  legacyCompatibility: {
-    injectsClientId: boolean;
-    injectsDefaultScopes: boolean;
-    addsLegacyTokenAliases: boolean;
-    acceptsLegacyJwtSigningKey: boolean;
-  };
 }
 
 export function IdentityServer() {
@@ -126,15 +120,6 @@ export function IdentityServer() {
               </div>
             </div>
 
-            <div className="card !p-5">
-              <h2 className="text-sm font-semibold text-ink-50">Legacy compatibility</h2>
-              <div className="mt-4 grid gap-3 md:grid-cols-2">
-                <Compatibility label="Inject client_id for old clients" ok={settings.legacyCompatibility.injectsClientId} />
-                <Compatibility label="Merge default scopes" ok={settings.legacyCompatibility.injectsDefaultScopes} />
-                <Compatibility label="Add legacy token aliases" ok={settings.legacyCompatibility.addsLegacyTokenAliases} />
-                <Compatibility label="Accept legacy JWT signing key" ok={settings.legacyCompatibility.acceptsLegacyJwtSigningKey} />
-              </div>
-            </div>
           </div>
 
           <div className="space-y-5">
@@ -194,15 +179,6 @@ function Metric({ label, value }: { label: string; value: string }) {
     <div className="rounded-lg border border-ink-800 bg-ink-950/30 p-3">
       <div className="text-[11px] uppercase text-ink-500">{label}</div>
       <div className="mt-1 text-sm font-semibold text-ink-50">{value}</div>
-    </div>
-  );
-}
-
-function Compatibility({ label, ok }: { label: string; ok: boolean }) {
-  return (
-    <div className="flex min-h-10 items-center justify-between gap-3 rounded-md border border-ink-800 bg-ink-950/30 px-3 py-2">
-      <span className="text-xs text-ink-100">{label}</span>
-      <StatusBadge ok={ok} on="On" off="Off" />
     </div>
   );
 }

--- a/DorkNet.Server/admin-ui/src/pages/SettingsHome.tsx
+++ b/DorkNet.Server/admin-ui/src/pages/SettingsHome.tsx
@@ -1,4 +1,5 @@
 import { Settings } from './Settings';
+import { IdentityServer } from './IdentityServer';
 import { SignupCodes } from './SignupCodes';
 import { PageHeader } from '../components/PageHeader';
 import { Tabs, useTabParam } from '../components/Tabs';
@@ -7,19 +8,21 @@ import { Tabs, useTabParam } from '../components/Tabs';
 // invite codes (an access-control setting in its own right). Old
 // /signup-codes route redirects here with ?tab=signup.
 export function SettingsHome() {
-  const [tab, setTab] = useTabParam<'server' | 'signup'>('server', ['server', 'signup']);
+  const [tab, setTab] = useTabParam<'server' | 'identity' | 'signup'>('server', ['server', 'identity', 'signup']);
   return (
     <div>
-      <PageHeader title="Settings" blurb="Runtime server toggles and single-use signup invite codes." />
+      <PageHeader title="Settings" blurb="Runtime server toggles, authentication, and single-use signup invite codes." />
       <Tabs
         tabs={[
           { key: 'server', label: 'Server' },
+          { key: 'identity', label: 'IdentityServer' },
           { key: 'signup', label: 'Signup codes' },
         ]}
         active={tab}
         onChange={setTab}
       />
       {tab === 'server' && <Settings embedded />}
+      {tab === 'identity' && <IdentityServer />}
       {tab === 'signup' && <SignupCodes embedded />}
     </div>
   );

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ cd DorkNet
 | `ConnectionStrings:Redis` | `ConnectionStrings__Redis` | no | enables SignalR backplane |
 | `Domain:Apex` | `DORKNET_DOMAIN` | no | defaults to `localhost`; set for production |
 
+`/connect/token` issues access and refresh tokens with the configured
+auth host as the issuer. Set `DORKNET_DOMAIN` for production so OpenID
+discovery and JWT validation agree on `https://auth.<domain>`.
+
 **4. Boot:**
 
 ```pwsh

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ discovery and JWT validation agree on `https://auth.<domain>`.
 dotnet run --project DorkNet.Server
 ```
 
-First boot creates `bin/Debug/net9.0/data/dorknet.db`, applies all EF
+First boot creates `bin/Debug/net10.0/data/dorknet.db`, applies all EF
 migrations under `DorkNet.Server/Migrations/`, seeds canonical rooms +
 store catalog, and starts listening. You should see `Application
 started.` in the log; `curl http://localhost:8080/healthz` returns 200.


### PR DESCRIPTION
## Summary
- Replace Duende IdentityServer package/namespaces with Open.IdentityServer.
- Retarget server-side projects and Docker images to .NET 10 because Open.IdentityServer 1.0.0 requires `net10.0`.
- Remove license-key wiring and license-status UI.
- Update ASP.NET/EF Core/Redis packages on the .NET 10 line and pin MessagePack 3.1.7 to clear the MessagePack advisories.
- Keep the game client auth flow on the native `recroom` client credentials.

## Verification
- `C:\Users\Alexa\.dotnet\dotnet.exe build DorkNet.Server\DorkNet.Server.csproj --nologo`
- `npm run build` in `DorkNet.Server\admin-ui`
- `C:\Users\Alexa\.dotnet\dotnet.exe list DorkNet.Server\DorkNet.Server.csproj package --vulnerable --include-transitive`

## Notes
- This worktree does not include a server test project.
- MessagePack advisories are cleared.
- `SQLitePCLRaw.lib.e_sqlite3 2.1.11` remains as a transitive EF Core SQLite advisory; NuGet currently has no patched `SQLitePCLRaw.lib.e_sqlite3` release beyond 2.1.11.